### PR TITLE
HOLO-544: Add abstract ERC721H tests

### DIFF
--- a/test/19_ERC721H_tests.ts
+++ b/test/19_ERC721H_tests.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import { ERC721H, MockExternalCall, MockExternalCall__factory } from '../typechain-types';
+import { functionHash, generateInitCode } from '../scripts/utils/helpers';
+import setup, { PreTest } from './utils';
+import { HOLOGRAPHER_ALREADY_INITIALIZED_ERROR_MSG } from './utils/error_constants';
+
+describe('ERC721H Contract', async function () {
+  let erc721H: ERC721H;
+  let l1: PreTest;
+  let mockExternalCall: MockExternalCall;
+
+  before(async function () {
+    l1 = await setup();
+    erc721H = await ethers.getContractAt('ERC721H', l1.sampleErc721Holographer.address);
+    const mockExternalCallFactory = await ethers.getContractFactory<MockExternalCall__factory>('MockExternalCall');
+    mockExternalCall = await mockExternalCallFactory.deploy();
+    await mockExternalCall.deployed();
+  });
+
+  async function testExternalCallToFunction(fnAbi: string, fnName: string, args: any[] = []) {
+    const ABI = [fnAbi];
+    const iface = new ethers.utils.Interface(ABI);
+    const encodedFunctionData = iface.encodeFunctionData(fnName, args);
+    await expect(mockExternalCall.connect(l1.deployer).callExternalFn(erc721H.address, encodedFunctionData)).to.not.be
+      .reverted;
+  }
+
+  describe('init()', async function () {
+    it('should fail be initialized twice', async function () {
+      const initCode = generateInitCode(['address'], [l1.deployer.address]);
+      await expect(erc721H.connect(l1.deployer).init(initCode)).to.be.revertedWith(
+        HOLOGRAPHER_ALREADY_INITIALIZED_ERROR_MSG
+      );
+    });
+  });
+
+  describe('owner()', async function () {
+    it('should return the correct owner address', async function () {
+      const ownerAddress = await erc721H.connect(l1.deployer).owner();
+      expect(ownerAddress).to.equal(l1.deployer.address);
+    });
+    it('should fail when comparing to wrong address', async function () {
+      const ownerAddress = await erc721H.connect(l1.wallet10).owner();
+      expect(ownerAddress).to.not.equal(l1.wallet10.address);
+    });
+    it('should allow external contract to call fn', async function () {
+      await testExternalCallToFunction('function owner() external view returns (address)', 'owner');
+    });
+  });
+
+  describe('isOwner()', async function () {
+    it('should allow external contract to call fn', async function () {
+      await testExternalCallToFunction('function isOwner() external view returns (bool)', 'isOwner');
+    });
+    it('should allow external contract to call fn with params', async function () {
+      await testExternalCallToFunction('function isOwner(address wallet) external view returns (bool)', 'isOwner', [
+        l1.deployer.address,
+      ]);
+    });
+  });
+
+  describe('supportsInterface()', async function () {
+    const validInterface = functionHash('totalSupply()');
+    const invalidInterface = functionHash('invalidMethod(address,address,uint256,bytes)');
+
+    it('should return true if interface is valid', async function () {
+      const supportsInterface = await erc721H.connect(l1.deployer).supportsInterface(validInterface);
+      expect(supportsInterface).to.equal(true);
+    });
+
+    it('should return false if interface is invalid', async function () {
+      const supportsInterface = await erc721H.connect(l1.deployer).supportsInterface(invalidInterface);
+      expect(supportsInterface).to.equal(false);
+    });
+
+    it('should allow external contract to call fn', async function () {
+      await testExternalCallToFunction(
+        'function supportsInterface(bytes4) external pure returns (bool)',
+        'supportsInterface',
+        [validInterface]
+      );
+    });
+  });
+});

--- a/test/utils/error_constants.ts
+++ b/test/utils/error_constants.ts
@@ -1,5 +1,6 @@
 export const ONLY_ADMIN_ERROR_MSG = 'HOLOGRAPH: admin only function';
 export const ALREADY_INITIALIZED_ERROR_MSG = 'HOLOGRAPH: already initialized';
+export const HOLOGRAPHER_ALREADY_INITIALIZED_ERROR_MSG = 'HOLOGRAPHER: already initialized';
 export const FACTORY_ONLY_ERROR_MSG = 'HOLOGRAPH: factory only function';
 export const EMPTY_CONTRACT_ERROR_MSG = 'HOLOGRAPH: empty contract';
 export const CONTRACT_ALREADY_SET_ERROR_MSG = 'HOLOGRAPH: contract already set';


### PR DESCRIPTION
## Describe Changes

I made this more better by doing ...

- Added tests for `contracts/abstract/ERC721H.sol` on `19_ERC721H_tests.ts`
- ps: There are methods of this contract file that are not within the test file because part of them are `internal` and not really testable functions

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] All Hardhat tests are passing