### PR TITLE
Feature/HOLO-685: Final protocol changes for mainnet deployment

### DIFF
--- a/abi/experimental/HolographERC20.json
+++ b/abi/experimental/HolographERC20.json
@@ -335,19 +335,6 @@
   },
   {
     "inputs": [],
-    "name": "getContractType",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "contractType",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "getOwner",
     "outputs": [
       {

--- a/abi/experimental/HolographERC721.json
+++ b/abi/experimental/HolographERC721.json
@@ -339,19 +339,6 @@
   },
   {
     "inputs": [],
-    "name": "getContractType",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "contractType",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "getOwner",
     "outputs": [
       {

--- a/abi/experimental/HolographGeneric.json
+++ b/abi/experimental/HolographGeneric.json
@@ -131,19 +131,6 @@
   },
   {
     "inputs": [],
-    "name": "getContractType",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "contractType",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "getOwner",
     "outputs": [
       {

--- a/contracts/HolographRegistry.sol
+++ b/contracts/HolographRegistry.sol
@@ -195,10 +195,7 @@ contract HolographRegistry is Admin, Initializable, HolographRegistryInterface {
     assembly {
       contractType := extcodehash(contractAddress)
     }
-    require(
-      (contractType != 0x0 && contractType != 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470),
-      "HOLOGRAPH: empty contract"
-    );
+    require((contractType != 0x0 && contractType != 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470), "HOLOGRAPH: empty contract");
     require(_contractTypeAddresses[contractType] == address(0), "HOLOGRAPH: contract already set");
     require(!_reservedTypes[contractType], "HOLOGRAPH: reserved address type");
     _contractTypeAddresses[contractType] = contractAddress;

--- a/contracts/HolographRegistry.sol
+++ b/contracts/HolographRegistry.sol
@@ -195,7 +195,10 @@ contract HolographRegistry is Admin, Initializable, HolographRegistryInterface {
     assembly {
       contractType := extcodehash(contractAddress)
     }
-    require((contractType != 0x0 && contractType != 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470), "HOLOGRAPH: empty contract");
+    require(
+      (contractType != 0x0 && contractType != 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470),
+      "HOLOGRAPH: empty contract"
+    );
     require(_contractTypeAddresses[contractType] == address(0), "HOLOGRAPH: contract already set");
     require(!_reservedTypes[contractType], "HOLOGRAPH: reserved address type");
     _contractTypeAddresses[contractType] = contractAddress;

--- a/contracts/enforcer/HolographERC20.sol
+++ b/contracts/enforcer/HolographERC20.sol
@@ -849,20 +849,4 @@ contract HolographERC20 is Admin, Owner, Initializable, NonReentrant, EIP712, Ho
   function _isEventRegistered(HolographERC20Event _eventName) private view returns (bool) {
     return ((_eventConfig >> uint256(_eventName)) & uint256(1) == 1 ? true : false);
   }
-
-  // the code below is temporary, in place to prevent Holographers on testnet from having different deployment addresses
-
-  /**
-   * @dev bytes32(uint256(keccak256('eip1967.Holograph.contractType')) - 1)
-   */
-  bytes32 constant _contractTypeSlot = 0x0b671eb65810897366dd82c4cbb7d9dff8beda8484194956e81e89b8a361d9c7;
-
-  /**
-   * @dev Returns the contract type that is used for loading the Enforcer
-   */
-  function getContractType() external view returns (bytes32 contractType) {
-    assembly {
-      contractType := sload(_contractTypeSlot)
-    }
-  }
 }

--- a/contracts/enforcer/HolographERC721.sol
+++ b/contracts/enforcer/HolographERC721.sol
@@ -1010,7 +1010,9 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
    */
   function _royalties() private view returns (address) {
     return
-      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573);
+      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(
+        0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573
+      );
   }
 
   /**

--- a/contracts/enforcer/HolographERC721.sol
+++ b/contracts/enforcer/HolographERC721.sol
@@ -1010,9 +1010,7 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
    */
   function _royalties() private view returns (address) {
     return
-      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(
-        0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573
-      );
+      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573);
   }
 
   /**

--- a/contracts/enforcer/HolographERC721.sol
+++ b/contracts/enforcer/HolographERC721.sol
@@ -1010,9 +1010,7 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
    */
   function _royalties() private view returns (address) {
     return
-      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(
-        0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573
-      );
+      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573);
   }
 
   /**
@@ -1078,21 +1076,5 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
 
   function _isEventRegistered(HolographERC721Event _eventName) private view returns (bool) {
     return ((_eventConfig >> uint256(_eventName)) & uint256(1) == 1 ? true : false);
-  }
-
-  // the code below is temporary, in place to prevent Holographers on testnet from having different deployment addresses
-
-  /**
-   * @dev bytes32(uint256(keccak256('eip1967.Holograph.contractType')) - 1)
-   */
-  bytes32 constant _contractTypeSlot = 0x0b671eb65810897366dd82c4cbb7d9dff8beda8484194956e81e89b8a361d9c7;
-
-  /**
-   * @dev Returns the contract type that is used for loading the Enforcer
-   */
-  function getContractType() external view returns (bytes32 contractType) {
-    assembly {
-      contractType := sload(_contractTypeSlot)
-    }
   }
 }

--- a/contracts/enforcer/HolographGeneric.sol
+++ b/contracts/enforcer/HolographGeneric.sol
@@ -380,20 +380,4 @@ contract HolographGeneric is Admin, Owner, Initializable, HolographGenericInterf
   function _isEventRegistered(HolographGenericEvent _eventName) private view returns (bool) {
     return ((_eventConfig >> uint256(_eventName)) & uint256(1) == 1 ? true : false);
   }
-
-  // the code below is temporary, in place to prevent Holographers on testnet from having different deployment addresses
-
-  /**
-   * @dev bytes32(uint256(keccak256('eip1967.Holograph.contractType')) - 1)
-   */
-  bytes32 constant _contractTypeSlot = 0x0b671eb65810897366dd82c4cbb7d9dff8beda8484194956e81e89b8a361d9c7;
-
-  /**
-   * @dev Returns the contract type that is used for loading the Enforcer
-   */
-  function getContractType() external view returns (bytes32 contractType) {
-    assembly {
-      contractType := sload(_contractTypeSlot)
-    }
-  }
 }

--- a/contracts/interface/HolographTreasuryInterface.sol
+++ b/contracts/interface/HolographTreasuryInterface.sol
@@ -101,6 +101,4 @@
 
 pragma solidity 0.8.13;
 
-interface HolographTreasuryInterface {
-
-}
+interface HolographTreasuryInterface {}

--- a/contracts/interface/HolographTreasuryInterface.sol
+++ b/contracts/interface/HolographTreasuryInterface.sol
@@ -101,4 +101,6 @@
 
 pragma solidity 0.8.13;
 
-interface HolographTreasuryInterface {}
+interface HolographTreasuryInterface {
+
+}

--- a/contracts/token/HolographUtilityToken.sol
+++ b/contracts/token/HolographUtilityToken.sol
@@ -132,14 +132,13 @@ contract HolographUtilityToken is ERC20H {
     );
     _setOwner(contractOwner);
     /*
-     * @dev Mint token only if target chain matches current chain.
+     * @dev Mint token only if target chain matches current chain. Or if no target chain has been selected.
      *      Goal of this is to restrict minting on Ethereum only for mainnet deployment.
      */
-    if (block.chainid == targetChain) {
-      /*
-       * @dev Mint only 10 billion tokens on mainnet (10_000_000_000)
-       */
-      HolographERC20Interface(msg.sender).sourceMint(tokenRecipient, tokenAmount * (10**18));
+    if (block.chainid == targetChain || targetChain == 0) {
+      if (tokenAmount > 0) {
+        HolographERC20Interface(msg.sender).sourceMint(tokenRecipient, tokenAmount * (10**18));
+      }
     }
     // run underlying initializer logic
     return _init(initPayload);

--- a/contracts/token/HolographUtilityToken.sol
+++ b/contracts/token/HolographUtilityToken.sol
@@ -126,9 +126,21 @@ contract HolographUtilityToken is ERC20H {
    * @param initPayload abi encoded payload to use for contract initilaization
    */
   function init(bytes memory initPayload) external override returns (bytes4) {
-    address contractOwner = abi.decode(initPayload, (address));
+    (address contractOwner, uint256 tokenAmount, uint256 targetChain, address tokenRecipient) = abi.decode(
+      initPayload,
+      (address, uint256, uint256, address)
+    );
     _setOwner(contractOwner);
-    HolographERC20Interface(msg.sender).sourceMint(contractOwner, 10000000 * (10**18));
+    /*
+     * @dev Mint token only if target chain matches current chain.
+     *      Goal of this is to restring minting on Ethereum only for mainnet deployment.
+     */
+    if (block.chainid == targetChain) {
+      /*
+       * @dev Mint only 10 billion tokens on mainnet (10_000_000_000)
+       */
+      HolographERC20Interface(msg.sender).sourceMint(tokenRecipient, tokenAmount * (10**18));
+    }
     // run underlying initializer logic
     return _init(initPayload);
   }

--- a/contracts/token/HolographUtilityToken.sol
+++ b/contracts/token/HolographUtilityToken.sol
@@ -133,7 +133,7 @@ contract HolographUtilityToken is ERC20H {
     _setOwner(contractOwner);
     /*
      * @dev Mint token only if target chain matches current chain.
-     *      Goal of this is to restring minting on Ethereum only for mainnet deployment.
+     *      Goal of this is to restrict minting on Ethereum only for mainnet deployment.
      */
     if (block.chainid == targetChain) {
       /*

--- a/deploy/02_sources.ts
+++ b/deploy/02_sources.ts
@@ -52,6 +52,7 @@ import { NetworkType, Network, networks } from '@holographxyz/networks';
 import { SuperColdStorageSigner } from 'super-cold-storage-signer';
 
 const GWEI: BigNumber = BigNumber.from('1000000000');
+const ZERO: BigNumber = BigNumber.from('0');
 
 const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
   let { hre, hre2 } = await hreSplit(hre1, global.__companionNetwork);
@@ -224,14 +225,34 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
   );
   hre.deployments.log('the future "HolographRoyalties" address is', futureRoyaltiesAddress);
 
+  const network = networks[hre.networkName];
+
+  let tokenAmount: BigNumber = BigNumber.from('100000000');
+  let targetChain: BigNumber = BigNumber.from(network.chain);
+  let tokenRecipient: string = deployer.address;
+
   // Future Holograph Utility Token
-  const currentNetworkType: NetworkType = networks[hre.networkName].type;
+  const currentNetworkType: NetworkType = network.type;
   let primaryNetwork: Network;
   if (currentNetworkType == NetworkType.local) {
+    // one billion tokens minted per network on local testing
+    tokenAmount = BigNumber.from('1' + '000' + '000' + '000' + '000000000000000000');
     primaryNetwork = networks.localhost;
   } else if (currentNetworkType == NetworkType.testnet) {
+    // one hundred million tokens minted per network on testnets
+    tokenAmount = BigNumber.from('100' + '000' + '000' + '000000000000000000');
     primaryNetwork = networks.ethereumTestnetGoerli;
   } else if (currentNetworkType == NetworkType.mainnet) {
+    // ten billion tokens minted on ethereum on mainnet
+    tokenAmount = BigNumber.from('10' + '000' + '000' + '000' + '000000000000000000');
+    // target chain is restricted to ethereum, to prevent the minting of tokens on other chains
+    targetChain = BigNumber.from(networks.ethereum.chain);
+    // protocol multisig is the recipient
+    if (network.key == networks.ethereum.key) {
+      tokenRecipient = networks.ethereum.protocolMultisig;
+    } else {
+      tokenRecipient = zeroAddress;
+    }
     primaryNetwork = networks.ethereum;
   } else {
     throw new Error('cannot identity current NetworkType');
@@ -247,7 +268,10 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
     '1',
     18,
     ConfigureEvents([]),
-    generateInitCode(['address'], [deployer.address]),
+    generateInitCode(
+      ['address', 'uint256', 'uint256', 'address'],
+      [deployer.address, tokenAmount, targetChain, tokenRecipient]
+    ),
     salt
   );
 

--- a/deploy/02_sources.ts
+++ b/deploy/02_sources.ts
@@ -266,7 +266,7 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
     ConfigureEvents([]),
     generateInitCode(
       ['address', 'uint256', 'uint256', 'address'],
-      [deployer.address, tokenAmount, targetChain, tokenRecipient]
+      [deployer.address, tokenAmount.toHexString(), targetChain.toHexString(), tokenRecipient]
     ),
     salt
   );

--- a/deploy/02_sources.ts
+++ b/deploy/02_sources.ts
@@ -227,7 +227,7 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
 
   const network = networks[hre.networkName];
 
-  let tokenAmount: BigNumber = BigNumber.from('100000000');
+  let tokenAmount: BigNumber = BigNumber.from('100' + '000' + '000' + '000000000000000000');
   let targetChain: BigNumber = BigNumber.from(network.chain);
   let tokenRecipient: string = deployer.address;
 

--- a/deploy/02_sources.ts
+++ b/deploy/02_sources.ts
@@ -248,11 +248,7 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
     // target chain is restricted to ethereum, to prevent the minting of tokens on other chains
     targetChain = BigNumber.from(networks.ethereum.chain);
     // protocol multisig is the recipient
-    if (network.key == networks.ethereum.key) {
-      tokenRecipient = networks.ethereum.protocolMultisig;
-    } else {
-      tokenRecipient = zeroAddress;
-    }
+    tokenRecipient = networks.ethereum.protocolMultisig;
     primaryNetwork = networks.ethereum;
   } else {
     throw new Error('cannot identity current NetworkType');

--- a/deploy/02_sources.ts
+++ b/deploy/02_sources.ts
@@ -228,7 +228,7 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
   const network = networks[hre.networkName];
 
   let tokenAmount: BigNumber = BigNumber.from('100' + '000' + '000' + '000000000000000000');
-  let targetChain: BigNumber = BigNumber.from(network.chain);
+  let targetChain: BigNumber = BigNumber.from('0');
   let tokenRecipient: string = deployer.address;
 
   // Future Holograph Utility Token

--- a/deploy/21_hlg.ts
+++ b/deploy/21_hlg.ts
@@ -104,7 +104,7 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
     ConfigureEvents([]),
     generateInitCode(
       ['address', 'uint256', 'uint256', 'address'],
-      [deployer.address, tokenAmount, targetChain, tokenRecipient]
+      [deployer.address, tokenAmount.toHexString(), targetChain.toHexString(), tokenRecipient]
     ),
     salt
   );

--- a/deploy/21_hlg.ts
+++ b/deploy/21_hlg.ts
@@ -65,14 +65,28 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
     process.exit();
   };
 
+  let tokenAmount: BigNumber = BigNumber.from('100000000');
+  let targetChain: BigNumber = BigNumber.from(network.chain);
+  let tokenRecipient: string = deployer.address;
+
   // Future Holograph Utility Token
   const currentNetworkType: NetworkType = network.type;
   let primaryNetwork: Network;
   if (currentNetworkType == NetworkType.local) {
+    // one billion tokens minted per network on local testing
+    tokenAmount = BigNumber.from('1' + '000' + '000' + '000' + '000000000000000000');
     primaryNetwork = networks.localhost;
   } else if (currentNetworkType == NetworkType.testnet) {
+    // one hundred million tokens minted per network on testnets
+    tokenAmount = BigNumber.from('100' + '000' + '000' + '000000000000000000');
     primaryNetwork = networks.ethereumTestnetGoerli;
   } else if (currentNetworkType == NetworkType.mainnet) {
+    // ten billion tokens minted on ethereum on mainnet
+    tokenAmount = BigNumber.from('10' + '000' + '000' + '000' + '000000000000000000');
+    // target chain is restricted to ethereum, to prevent the minting of tokens on other chains
+    targetChain = BigNumber.from(networks.ethereum.chain);
+    // protocol multisig is the recipient
+    tokenRecipient = networks.ethereum.protocolMultisig;
     primaryNetwork = networks.ethereum;
   } else {
     throw new Error('cannot identity current NetworkType');
@@ -88,7 +102,10 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
     '1',
     18,
     ConfigureEvents([]),
-    generateInitCode(['address'], [deployer.address]),
+    generateInitCode(
+      ['address', 'uint256', 'uint256', 'address'],
+      [deployer.address, tokenAmount, targetChain, tokenRecipient]
+    ),
     salt
   );
 

--- a/deploy/21_hlg.ts
+++ b/deploy/21_hlg.ts
@@ -66,7 +66,7 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
   };
 
   let tokenAmount: BigNumber = BigNumber.from('100000000');
-  let targetChain: BigNumber = BigNumber.from(network.chain);
+  let targetChain: BigNumber = BigNumber.from('0');
   let tokenRecipient: string = deployer.address;
 
   // Future Holograph Utility Token

--- a/deploy/29_faucet.ts
+++ b/deploy/29_faucet.ts
@@ -65,7 +65,7 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
       if (currentNetworkType == NetworkType.testnet) {
         const transferTx = await hlgContract.transfer(
           futureFaucetAddress,
-          BigNumber.from('1000000000000000000000000'),
+          BigNumber.from('1' + '000' + '000' + '000000000000000000'),
           {
             ...(await txParams({
               hre,
@@ -75,7 +75,7 @@ const func: DeployFunction = async function (hre1: HardhatRuntimeEnvironment) {
                 await hre.ethers.provider.estimateGas(
                   hlgContract.populateTransaction.transfer(
                     futureFaucetAddress,
-                    BigNumber.from('1000000000000000000000000')
+                    BigNumber.from('1' + '000' + '000' + '000000000000000000')
                   )
                 )
               ).mul(BigNumber.from('2')),

--- a/src/HolographOperator.sol
+++ b/src/HolographOperator.sol
@@ -286,9 +286,9 @@ contract HolographOperator is Admin, Initializable, HolographOperatorInterface {
         /**
          * @dev only allow HLG rewards to go to bonded operators
          *      if operator is bonded, the slashed amount is sent to current operator
-         *      otherwise it's sent to HLG directly, can be burned or sent to treasury from there
+         *      otherwise it's sent to HolographTreasury, can be burned or distributed from there
          */
-        _utilityToken().transfer((isBonded ? msg.sender : address(_utilityToken())), amount);
+        _utilityToken().transfer((isBonded ? msg.sender : address(_holograph().getTreasury())), amount);
         /**
          * @dev check if slashed operator has enough tokens bonded to stay
          */
@@ -325,9 +325,9 @@ contract HolographOperator is Admin, Initializable, HolographOperatorInterface {
     /**
      * @dev reward operator (with HLG) for executing the job
      *      this is out of scope and is purposefully omitted from code
-     *      currently reward is statically set to 1 token
+     *      currently no rewards are issued
      */
-    _utilityToken().transfer((isBonded ? msg.sender : address(_utilityToken())), (10**18));
+    //_utilityToken().transfer((isBonded ? msg.sender : address(_utilityToken())), (10**18));
     /**
      * @dev always emit an event at end of job, this helps other operators keep track of job status
      */
@@ -417,10 +417,16 @@ contract HolographOperator is Admin, Initializable, HolographOperatorInterface {
        * @dev use job hash, job nonce, block number, and block timestamp for generating a random number
        */
       uint256 random = uint256(keccak256(abi.encodePacked(jobHash, _jobNonce(), block.number, block.timestamp)));
+      // use the left 128 bits of random number
+      uint256 random1 = uint256(random >> 128);
+      // use the right 128 bits of random number
+      uint256 random2 = uint256(uint128(random));
+      // combine the two new random numbers for use in additional pod operator selection logic
+      random = uint256(keccak256(abi.encodePacked(random1 + random2)));
       /**
        * @dev divide by total number of pods, use modulus/remainder
        */
-      uint256 pod = random % _operatorPods.length;
+      uint256 pod = random1 % _operatorPods.length;
       /**
        * @dev identify the total number of available operators in pod
        */
@@ -428,7 +434,7 @@ contract HolographOperator is Admin, Initializable, HolographOperatorInterface {
       /**
        * @dev select a primary operator
        */
-      uint256 operatorIndex = underpriced ? 0 : random % podSize;
+      uint256 operatorIndex = underpriced ? 0 : random2 % podSize;
       /**
        * @dev If operator index is 0, then it's open season! Anyone can execute this job. First come first serve
        *      pop operator to ensure that they cannot be selected for any other job until this one completes

--- a/src/enforcer/HolographERC20.sol
+++ b/src/enforcer/HolographERC20.sol
@@ -750,20 +750,4 @@ contract HolographERC20 is Admin, Owner, Initializable, NonReentrant, EIP712, Ho
   function _isEventRegistered(HolographERC20Event _eventName) private view returns (bool) {
     return ((_eventConfig >> uint256(_eventName)) & uint256(1) == 1 ? true : false);
   }
-
-  // the code below is temporary, in place to prevent Holographers on testnet from having different deployment addresses
-
-  /**
-   * @dev bytes32(uint256(keccak256('eip1967.Holograph.contractType')) - 1)
-   */
-  bytes32 constant _contractTypeSlot = precomputeslot("eip1967.Holograph.contractType");
-
-  /**
-   * @dev Returns the contract type that is used for loading the Enforcer
-   */
-  function getContractType() external view returns (bytes32 contractType) {
-    assembly {
-      contractType := sload(_contractTypeSlot)
-    }
-  }
 }

--- a/src/enforcer/HolographERC721.sol
+++ b/src/enforcer/HolographERC721.sol
@@ -978,20 +978,4 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
   function _isEventRegistered(HolographERC721Event _eventName) private view returns (bool) {
     return ((_eventConfig >> uint256(_eventName)) & uint256(1) == 1 ? true : false);
   }
-
-  // the code below is temporary, in place to prevent Holographers on testnet from having different deployment addresses
-
-  /**
-   * @dev bytes32(uint256(keccak256('eip1967.Holograph.contractType')) - 1)
-   */
-  bytes32 constant _contractTypeSlot = precomputeslot("eip1967.Holograph.contractType");
-
-  /**
-   * @dev Returns the contract type that is used for loading the Enforcer
-   */
-  function getContractType() external view returns (bytes32 contractType) {
-    assembly {
-      contractType := sload(_contractTypeSlot)
-    }
-  }
 }

--- a/src/enforcer/HolographGeneric.sol
+++ b/src/enforcer/HolographGeneric.sol
@@ -281,20 +281,4 @@ contract HolographGeneric is Admin, Owner, Initializable, HolographGenericInterf
   function _isEventRegistered(HolographGenericEvent _eventName) private view returns (bool) {
     return ((_eventConfig >> uint256(_eventName)) & uint256(1) == 1 ? true : false);
   }
-
-  // the code below is temporary, in place to prevent Holographers on testnet from having different deployment addresses
-
-  /**
-   * @dev bytes32(uint256(keccak256('eip1967.Holograph.contractType')) - 1)
-   */
-  bytes32 constant _contractTypeSlot = precomputeslot("eip1967.Holograph.contractType");
-
-  /**
-   * @dev Returns the contract type that is used for loading the Enforcer
-   */
-  function getContractType() external view returns (bytes32 contractType) {
-    assembly {
-      contractType := sload(_contractTypeSlot)
-    }
-  }
 }

--- a/src/token/HolographUtilityToken.sol
+++ b/src/token/HolographUtilityToken.sol
@@ -33,14 +33,13 @@ contract HolographUtilityToken is ERC20H {
     );
     _setOwner(contractOwner);
     /*
-     * @dev Mint token only if target chain matches current chain.
+     * @dev Mint token only if target chain matches current chain. Or if no target chain has been selected.
      *      Goal of this is to restrict minting on Ethereum only for mainnet deployment.
      */
-    if (block.chainid == targetChain) {
-      /*
-       * @dev Mint only 10 billion tokens on mainnet (10_000_000_000)
-       */
-      HolographERC20Interface(msg.sender).sourceMint(tokenRecipient, tokenAmount * (10**18));
+    if (block.chainid == targetChain || targetChain == 0) {
+      if (tokenAmount > 0) {
+        HolographERC20Interface(msg.sender).sourceMint(tokenRecipient, tokenAmount * (10**18));
+      }
     }
     // run underlying initializer logic
     return _init(initPayload);

--- a/src/token/HolographUtilityToken.sol
+++ b/src/token/HolographUtilityToken.sol
@@ -34,7 +34,7 @@ contract HolographUtilityToken is ERC20H {
     _setOwner(contractOwner);
     /*
      * @dev Mint token only if target chain matches current chain.
-     *      Goal of this is to restring minting on Ethereum only for mainnet deployment.
+     *      Goal of this is to restrict minting on Ethereum only for mainnet deployment.
      */
     if (block.chainid == targetChain) {
       /*

--- a/src/token/HolographUtilityToken.sol
+++ b/src/token/HolographUtilityToken.sol
@@ -27,9 +27,21 @@ contract HolographUtilityToken is ERC20H {
    * @param initPayload abi encoded payload to use for contract initilaization
    */
   function init(bytes memory initPayload) external override returns (bytes4) {
-    address contractOwner = abi.decode(initPayload, (address));
+    (address contractOwner, uint256 tokenAmount, uint256 targetChain, address tokenRecipient) = abi.decode(
+      initPayload,
+      (address, uint256, uint256, address)
+    );
     _setOwner(contractOwner);
-    HolographERC20Interface(msg.sender).sourceMint(contractOwner, 10000000 * (10**18));
+    /*
+     * @dev Mint token only if target chain matches current chain.
+     *      Goal of this is to restring minting on Ethereum only for mainnet deployment.
+     */
+    if (block.chainid == targetChain) {
+      /*
+       * @dev Mint only 10 billion tokens on mainnet (10_000_000_000)
+       */
+      HolographERC20Interface(msg.sender).sourceMint(tokenRecipient, tokenAmount * (10**18));
+    }
     // run underlying initializer logic
     return _init(initPayload);
   }


### PR DESCRIPTION
## Describe Changes

Making final adjustments for proper mainnet deployment.

- HLG can only be minted on `init`.
- HLG can only be minted once on `init` on **Ethereum** for mainnet.
- Modified tests to still work for localhost environment.
- Switched the slashed tokens to be sent HolographTreasury instead of HLG directly.
- Disable HLG rewards for operator jobs.
- Modified `random` value to be split into two separate values for pod and operator pod selection.
- Modified `random` value to be unique for selection of backup operators.
- Removed temporary code that was in place before `Holographer` had the values applied to it.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] All Hardhat tests are passing
