### PR TITLE
Hotfix/incorrect bridge out assembly

### DIFF
--- a/contracts/enforcer/HolographERC20.sol
+++ b/contracts/enforcer/HolographERC20.sol
@@ -440,17 +440,22 @@ contract HolographERC20 is Admin, Owner, Initializable, NonReentrant, EIP712, Ho
         amount
       );
       assembly {
-        mstore(add(sourcePayload, mload(sourcePayload)), caller())
+        // it is important to add 32 bytes in order to accommodate the first 32 bytes being used for storing length of bytes
+        mstore(add(sourcePayload, add(mload(sourcePayload), 0x20)), caller())
         let result := call(
           gas(),
           sload(_sourceContractSlot),
           callvalue(),
-          sourcePayload,
-          add(mload(sourcePayload), 32),
+          // start reading data from memory position, plus 32 bytes, to skip bytes length indicator
+          add(sourcePayload, 0x20),
+          // add an additional 32 bytes to bytes length to include the appended caller address
+          add(mload(sourcePayload), 0x20),
           0,
           0
         )
-        returndatacopy(data, 0, returndatasize())
+        // when reading back data, skip the first 32 bytes which is used to indicate bytes position in calldata
+        // also subtract 32 bytes from returndatasize to accomodate the skipped first 32 bytes
+        returndatacopy(data, 0x20, sub(returndatasize(), 0x20))
         switch result
         case 0 {
           revert(0, returndatasize())

--- a/contracts/enforcer/HolographERC721.sol
+++ b/contracts/enforcer/HolographERC721.sol
@@ -438,17 +438,22 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
         tokenId
       );
       assembly {
-        mstore(add(sourcePayload, mload(sourcePayload)), caller())
+        // it is important to add 32 bytes in order to accommodate the first 32 bytes being used for storing length of bytes
+        mstore(add(sourcePayload, add(mload(sourcePayload), 0x20)), caller())
         let result := call(
           gas(),
           sload(_sourceContractSlot),
           callvalue(),
-          sourcePayload,
-          add(mload(sourcePayload), 32),
+          // start reading data from memory position, plus 32 bytes, to skip bytes length indicator
+          add(sourcePayload, 0x20),
+          // add an additional 32 bytes to bytes length to include the appended caller address
+          add(mload(sourcePayload), 0x20),
           0,
           0
         )
-        returndatacopy(data, 0, returndatasize())
+        // when reading back data, skip the first 32 bytes which is used to indicate bytes position in calldata
+        // also subtract 32 bytes from returndatasize to accomodate the skipped first 32 bytes
+        returndatacopy(data, 0x20, sub(returndatasize(), 0x20))
         switch result
         case 0 {
           revert(0, returndatasize())

--- a/contracts/enforcer/HolographGeneric.sol
+++ b/contracts/enforcer/HolographGeneric.sol
@@ -274,17 +274,22 @@ contract HolographGeneric is Admin, Owner, Initializable, HolographGenericInterf
         payload
       );
       assembly {
-        mstore(add(sourcePayload, mload(sourcePayload)), caller())
+        // it is important to add 32 bytes in order to accommodate the first 32 bytes being used for storing length of bytes
+        mstore(add(sourcePayload, add(mload(sourcePayload), 0x20)), caller())
         let result := call(
           gas(),
           sload(_sourceContractSlot),
           callvalue(),
-          sourcePayload,
-          add(mload(sourcePayload), 32),
+          // start reading data from memory position, plus 32 bytes, to skip bytes length indicator
+          add(sourcePayload, 0x20),
+          // add an additional 32 bytes to bytes length to include the appended caller address
+          add(mload(sourcePayload), 0x20),
           0,
           0
         )
-        returndatacopy(data, 0, returndatasize())
+        // when reading back data, skip the first 32 bytes which is used to indicate bytes position in calldata
+        // also subtract 32 bytes from returndatasize to accomodate the skipped first 32 bytes
+        returndatacopy(data, 0x20, sub(returndatasize(), 0x20))
         switch result
         case 0 {
           revert(0, returndatasize())

--- a/src/enforcer/HolographERC20.sol
+++ b/src/enforcer/HolographERC20.sol
@@ -341,17 +341,22 @@ contract HolographERC20 is Admin, Owner, Initializable, NonReentrant, EIP712, Ho
         amount
       );
       assembly {
-        mstore(add(sourcePayload, mload(sourcePayload)), caller())
+        // it is important to add 32 bytes in order to accommodate the first 32 bytes being used for storing length of bytes
+        mstore(add(sourcePayload, add(mload(sourcePayload), 0x20)), caller())
         let result := call(
           gas(),
           sload(_sourceContractSlot),
           callvalue(),
-          sourcePayload,
-          add(mload(sourcePayload), 32),
+          // start reading data from memory position, plus 32 bytes, to skip bytes length indicator
+          add(sourcePayload, 0x20),
+          // add an additional 32 bytes to bytes length to include the appended caller address
+          add(mload(sourcePayload), 0x20),
           0,
           0
         )
-        returndatacopy(data, 0, returndatasize())
+        // when reading back data, skip the first 32 bytes which is used to indicate bytes position in calldata
+        // also subtract 32 bytes from returndatasize to accomodate the skipped first 32 bytes
+        returndatacopy(data, 0x20, sub(returndatasize(), 0x20))
         switch result
         case 0 {
           revert(0, returndatasize())

--- a/src/enforcer/HolographERC721.sol
+++ b/src/enforcer/HolographERC721.sol
@@ -339,17 +339,22 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
         tokenId
       );
       assembly {
-        mstore(add(sourcePayload, mload(sourcePayload)), caller())
+        // it is important to add 32 bytes in order to accommodate the first 32 bytes being used for storing length of bytes
+        mstore(add(sourcePayload, add(mload(sourcePayload), 0x20)), caller())
         let result := call(
           gas(),
           sload(_sourceContractSlot),
           callvalue(),
-          sourcePayload,
-          add(mload(sourcePayload), 32),
+          // start reading data from memory position, plus 32 bytes, to skip bytes length indicator
+          add(sourcePayload, 0x20),
+          // add an additional 32 bytes to bytes length to include the appended caller address
+          add(mload(sourcePayload), 0x20),
           0,
           0
         )
-        returndatacopy(data, 0, returndatasize())
+        // when reading back data, skip the first 32 bytes which is used to indicate bytes position in calldata
+        // also subtract 32 bytes from returndatasize to accomodate the skipped first 32 bytes
+        returndatacopy(data, 0x20, sub(returndatasize(), 0x20))
         switch result
         case 0 {
           revert(0, returndatasize())

--- a/src/enforcer/HolographGeneric.sol
+++ b/src/enforcer/HolographGeneric.sol
@@ -175,17 +175,22 @@ contract HolographGeneric is Admin, Owner, Initializable, HolographGenericInterf
         payload
       );
       assembly {
-        mstore(add(sourcePayload, mload(sourcePayload)), caller())
+        // it is important to add 32 bytes in order to accommodate the first 32 bytes being used for storing length of bytes
+        mstore(add(sourcePayload, add(mload(sourcePayload), 0x20)), caller())
         let result := call(
           gas(),
           sload(_sourceContractSlot),
           callvalue(),
-          sourcePayload,
-          add(mload(sourcePayload), 32),
+          // start reading data from memory position, plus 32 bytes, to skip bytes length indicator
+          add(sourcePayload, 0x20),
+          // add an additional 32 bytes to bytes length to include the appended caller address
+          add(mload(sourcePayload), 0x20),
           0,
           0
         )
-        returndatacopy(data, 0, returndatasize())
+        // when reading back data, skip the first 32 bytes which is used to indicate bytes position in calldata
+        // also subtract 32 bytes from returndatasize to accomodate the skipped first 32 bytes
+        returndatacopy(data, 0x20, sub(returndatasize(), 0x20))
         switch result
         case 0 {
           revert(0, returndatasize())


### PR DESCRIPTION
## Describe Changes

Fixing incorrectly written logic for assembly in Enforcer bridgeOut requests.

- Fixed bridgeOut assembly code in HolographGeneric
- Fixed bridgeOut assembly code in HolographERC20
- Fixed bridgeOut assembly code in HolographERC721

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] All Hardhat tests are passing
