### PR TITLE
Feature: Loading HolographGenesis deployments as external deployments from dedicated npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@holographxyz/environment": "0.1.10",
     "@holographxyz/hardhat-deploy-holographed": "^0.0.5",
     "@holographxyz/hardhat-holograph-contract-builder": "^0.0.4",
+    "@holographxyz/holograph-genesis": "^0.0.1",
     "@holographxyz/networks": "0.1.15",
     "chai-ethers": "^0.0.1",
     "ganache": "^7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -547,10 +547,52 @@
   resolved "https://registry.yarnpkg.com/@holographxyz/hardhat-holograph-contract-builder/-/hardhat-holograph-contract-builder-0.0.4.tgz#da2eb5abfbe771ce9db217671b653a38f0e7fccf"
   integrity sha512-W/vWgHT6bZWdmJoWJxdWHnUCscrpOXbL1mo2WCDVtjrHQmXivMal7aRZw+ZeDfjTpcvGQ0SBxC+nJZZGCnuVDA==
 
+"@holographxyz/holograph-genesis@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@holographxyz/holograph-genesis/-/holograph-genesis-0.0.1.tgz#3c9ce2dc785849c92c9b9ae4adca4ef0446f78b4"
+  integrity sha512-zDqNo/8tUxJAl7eW8xclwBb4kH79vHN3AJAxluXwDY0z4+jb+ljHDHxLXt11L59/kMOsLHm2gL9zooCLdkkiiQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/providers" "^5.7.2"
+    "@ethersproject/units" "^5.7.0"
+    "@holographxyz/environment" "0.1.10"
+    "@holographxyz/hardhat-deploy-holographed" "^0.0.5"
+    "@holographxyz/hardhat-holograph-contract-builder" "^0.0.4"
+    "@holographxyz/networks" "0.1.16"
+    "@typechain/ethers-v5" "^9.0.0"
+    "@typechain/hardhat" "^4.0.0"
+    "@types/chai" "^4.3.0"
+    "@types/data-urls" "^2.0.1"
+    "@types/mocha" "^9.1.0"
+    "@types/node" "^17.0.21"
+    "@typescript-eslint/parser" "^5.42.1"
+    dotenv "^10.0.0"
+    ethers "^5.5.4"
+    path "^0.12.7"
+    super-cold-storage-signer "^0.0.4"
+    truffle-hdwallet-provider "^1.0.17"
+    ts-node "^10.1.0"
+    typechain "^7.0.0"
+    typescript "^4.3.5"
+    web3 "^1.7.0"
+    zksync-web3 "^0.4.0"
+
 "@holographxyz/networks@0.1.15":
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/@holographxyz/networks/-/networks-0.1.15.tgz#97a742ecbf38480fda128650f4a2298f2ab238ba"
   integrity sha512-tXpyaJS/1+fMowIzb1n3bzA49JuQ63BxEDurz+eCQW9Ky0kEIg0fLSPJQnv358/aCEkmlTISGz2gwxjKOFODyQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@holographxyz/environment" "0.1.10"
+    dotenv "^10.0.0"
+    path "^0.12.7"
+
+"@holographxyz/networks@0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@holographxyz/networks/-/networks-0.1.16.tgz#ae75a257c007a0ccf1c440c0bf04c569a230a427"
+  integrity sha512-cRk7D/kSWU12rdcMQHgjTkv9LsTNiq+1huOSq6LBe8sPXZTz0zdx+m9zeeM4Gt0XSsd7PnCrcqGIMPhkJ+vZjA==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
     "@holographxyz/environment" "0.1.10"


### PR DESCRIPTION
## Describe Changes

Switching to using `@holographxyz/holograph-genesis` npm package for HolographGenesis external deployments.

- Loading external deployments dynamically
- Loading deployment supported networks dynamically

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] All Hardhat tests are passing
