### PR TITLE
Initial progress on using holograph enabled drops for the tests in HolographERC721Drop.t.sol

### DIFF
--- a/contracts/HolographRegistry.sol
+++ b/contracts/HolographRegistry.sol
@@ -195,10 +195,7 @@ contract HolographRegistry is Admin, Initializable, HolographRegistryInterface {
     assembly {
       contractType := extcodehash(contractAddress)
     }
-    require(
-      (contractType != 0x0 && contractType != 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470),
-      "HOLOGRAPH: empty contract"
-    );
+    require((contractType != 0x0 && contractType != 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470), "HOLOGRAPH: empty contract");
     require(_contractTypeAddresses[contractType] == address(0), "HOLOGRAPH: contract already set");
     require(!_reservedTypes[contractType], "HOLOGRAPH: reserved address type");
     _contractTypeAddresses[contractType] = contractAddress;

--- a/contracts/drops/HolographERC721Drop.sol
+++ b/contracts/drops/HolographERC721Drop.sol
@@ -1152,7 +1152,10 @@ contract HolographERC721Drop is
     uint256 startTokenId,
     uint256 quantity
   ) internal virtual override {
-    if (from != msg.sender && address(operatorFilterRegistry).code.length > 0) {
+    if (
+      from != address(0) && // skip on mints
+      from != msg.sender // skip on transfers from sender
+    ) {
       if (!operatorFilterRegistry.isOperatorAllowed(address(this), msg.sender)) {
         revert OperatorNotAllowed(msg.sender);
       }

--- a/contracts/drops/HolographERC721Drop.sol
+++ b/contracts/drops/HolographERC721Drop.sol
@@ -1523,9 +1523,7 @@ contract HolographERC721Drop is
    */
   function _royalties() internal view returns (address) {
     return
-      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(
-        0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573
-      );
+      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573);
   }
 
   event FundsReceived(address indexed source, uint256 amount);

--- a/contracts/enforcer/HolographERC721.sol
+++ b/contracts/enforcer/HolographERC721.sol
@@ -1015,9 +1015,7 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
    */
   function _royalties() private view returns (address) {
     return
-      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(
-        0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573
-      );
+      HolographRegistryInterface(_holograph().getRegistry()).getContractTypeAddress(0x0000000000000000000000000000486f6c6f6772617068526f79616c74696573);
   }
 
   /**

--- a/contracts/interface/HolographTreasuryInterface.sol
+++ b/contracts/interface/HolographTreasuryInterface.sol
@@ -101,4 +101,6 @@
 
 pragma solidity 0.8.13;
 
-interface HolographTreasuryInterface {}
+interface HolographTreasuryInterface {
+
+}

--- a/contracts/struct/DropInitializer.sol
+++ b/contracts/struct/DropInitializer.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.13;
 
 /// @param holographFeeManager Holograph Fee Manager
 /// @param holographERC721TransferHelper Transfer helper
-/// @param marketFilterDAOAddress Market filter DAO address - Manage subscription to the DAO for marketplace filtering based off royalty payouts.
+/// @param marketFilterAddress Market filter address - Manage subscription to the for marketplace filtering based off royalty payouts.
 /// @param contractName Contract name
 /// @param contractSymbol Contract symbol
 /// @param initialOwner User that owns and can mint the edition, gets royalty and sales payouts and can update the base url if needed.

--- a/src/drops/HolographERC721Drop.sol
+++ b/src/drops/HolographERC721Drop.sol
@@ -1152,7 +1152,10 @@ contract HolographERC721Drop is
     uint256 startTokenId,
     uint256 quantity
   ) internal virtual override {
-    if (from != msg.sender && address(operatorFilterRegistry).code.length > 0) {
+    if (
+      from != address(0) && // skip on mints
+      from != msg.sender // skip on transfers from sender
+    ) {
       if (!operatorFilterRegistry.isOperatorAllowed(address(this), msg.sender)) {
         revert OperatorNotAllowed(msg.sender);
       }

--- a/src/struct/DropInitializer.sol
+++ b/src/struct/DropInitializer.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.13;
 
 /// @param holographFeeManager Holograph Fee Manager
 /// @param holographERC721TransferHelper Transfer helper
-/// @param marketFilterDAOAddress Market filter DAO address - Manage subscription to the DAO for marketplace filtering based off royalty payouts.
+/// @param marketFilterAddress Market filter address - Manage subscription to the for marketplace filtering based off royalty payouts.
 /// @param contractName Contract name
 /// @param contractSymbol Contract symbol
 /// @param initialOwner User that owns and can mint the edition, gets royalty and sales payouts and can update the base url if needed.

--- a/test/forge/HolographDropCreator.t.sol
+++ b/test/forge/HolographDropCreator.t.sol
@@ -20,13 +20,13 @@ import {IERC721AUpgradeable} from "../../contracts/drops/interfaces/IERC721AUpgr
 contract HolographDropCreatorTest is Test {
   address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
   address payable public constant DEFAULT_FUNDS_RECIPIENT_ADDRESS = payable(address(0x001));
-  address payable public constant DEFAULT_HOLOGRAPH_DAO_ADDRESS = payable(address(0x999));
+  address payable public constant HOLOGRAPH_TREASURY_ADDRESS = payable(address(0x999));
 
   HolographERC721Drop public erc721Drop;
   HolographDropCreator public impl;
   HolographDropCreator public creator;
 
-  HolographFeeManager public holographFeeManager;
+  HolographFeeManager public feeManager;
   EditionMetadataRenderer public editionMetadataRenderer;
   DropMetadataRenderer public dropMetadataRenderer;
 
@@ -47,17 +47,23 @@ contract HolographDropCreatorTest is Test {
   bytes private metadataInitializer;
 
   function setUp() public {
+    // Setup VM
+    // NOTE: These tests rely on the Holograph protocol being deployed to the local chain
+    //       At the moment, the deploy pipeline is still managed by Hardhat, so we need to
+    //       first run it via `yarn deploy:localhost` or `npx hardhat deploy --network localhost` before running the tests.
     uint256 forkId = vm.createFork("http://localhost:8545");
     vm.selectFork(forkId);
 
-    vm.prank(DEFAULT_HOLOGRAPH_DAO_ADDRESS);
-    holographFeeManager = new HolographFeeManager();
-    holographFeeManager.init(abi.encode(500, DEFAULT_HOLOGRAPH_DAO_ADDRESS));
+    // Setup signer wallet
+    // NOTE: This is the address that will be used to sign transactions
+    //       A signature is required to deploy Holographable contracts via the HolographFactory
+    alice = vm.addr(1);
+
+    vm.prank(HOLOGRAPH_TREASURY_ADDRESS);
+    feeManager = new HolographFeeManager();
+    feeManager.init(abi.encode(500, HOLOGRAPH_TREASURY_ADDRESS));
     editionMetadataRenderer = new EditionMetadataRenderer();
     dropMetadataRenderer = new DropMetadataRenderer();
-
-    // Setup signer wallet
-    alice = vm.addr(1);
 
     // Setup ERC721 Drop Properties
     name = "Holograph ERC721 Drop Collection";
@@ -76,8 +82,8 @@ contract HolographDropCreatorTest is Test {
 
   function test_CreateEdition() public {
     // Create implementations
-    HolographERC721Drop erc721Drop = new HolographERC721Drop();
-    HolographDropCreator creator = new HolographDropCreator();
+    erc721Drop = new HolographERC721Drop();
+    creator = new HolographDropCreator();
 
     // Initialize deployment with actual values
     creator.init(abi.encode(address(erc721Drop), address(editionMetadataRenderer), address(dropMetadataRenderer)));
@@ -112,8 +118,8 @@ contract HolographDropCreatorTest is Test {
 
   function test_CreateDrop() public {
     // Create implementations
-    HolographERC721Drop erc721Drop = new HolographERC721Drop();
-    HolographDropCreator creator = new HolographDropCreator();
+    erc721Drop = new HolographERC721Drop();
+    creator = new HolographDropCreator();
 
     // Initialize deployment with actual values
     creator.init(abi.encode(address(erc721Drop), address(editionMetadataRenderer), address(dropMetadataRenderer)));
@@ -144,8 +150,8 @@ contract HolographDropCreatorTest is Test {
 
   function test_CreateGenericDrop() public {
     // Create implementations
-    HolographERC721Drop erc721Drop = new HolographERC721Drop();
-    HolographDropCreator creator = new HolographDropCreator();
+    erc721Drop = new HolographERC721Drop();
+    creator = new HolographDropCreator();
 
     // Initialize deployment with actual values
     creator.init(abi.encode(address(erc721Drop), address(editionMetadataRenderer), address(dropMetadataRenderer)));
@@ -183,15 +189,15 @@ contract HolographDropCreatorTest is Test {
   }
 
   function test_CreateHolographEdition() public {
-    // Setup sale config
+    // Setup sale config for edition
     IHolographERC721Drop.SalesConfiguration memory saleConfig = IHolographERC721Drop.SalesConfiguration({
-      publicSaleStart: 0,
-      publicSaleEnd: type(uint64).max,
-      presaleStart: 0,
-      presaleEnd: 0,
-      publicSalePrice: 0.1 ether,
-      maxSalePurchasePerAddress: 0,
-      presaleMerkleRoot: bytes32(0)
+      publicSaleStart: 0, // starts now
+      publicSaleEnd: type(uint64).max, // never ends
+      presaleStart: 0, // never starts
+      presaleEnd: 0, // never ends
+      publicSalePrice: 0.1 ether, // 0.1 ETH
+      maxSalePurchasePerAddress: 0, // no limit
+      presaleMerkleRoot: bytes32(0) // no presale
     });
     bytes[] memory setupData = new bytes[](1);
     setupData[0] = abi.encodeWithSelector(
@@ -206,9 +212,9 @@ contract HolographDropCreatorTest is Test {
     );
     // Create initializer
     DropInitializer memory initializer = DropInitializer(
-      address(holographFeeManager), // HolographFeeManager,
+      address(feeManager), // HolographFeeManager,
       address(0), // HolographERC721TransferHelper
-      DEFAULT_HOLOGRAPH_DAO_ADDRESS,
+      address(0), // marketFilterAddress
       name,
       symbol,
       defaultAdmin,
@@ -237,20 +243,22 @@ contract HolographDropCreatorTest is Test {
     Verification memory signature = Verification(r, s, v);
     address signer = ecrecover(hash, v, r, s);
 
-    // Pass the payload hash, with the signature, and signer's address
+    // NOTE: This is the address of the HolographFactory that depends on a couple .env variables being set
+    //       Those variable are HOLOGRAPH_ENVIRONMENT="develop" and DEVELOP_DEPLOYMENT_SALT=1000
     HolographFactory factory = HolographFactory(payable(0x5Db4dB97fDfFB29cD85eA5484C3722095c413fc7));
     console.log("Factory address: ", address(factory));
     console.log("Holograph address: ", address(factory.getHolograph()));
     console.log("Registry address: ", address(factory.getRegistry()));
     console.log("Signer address: ", signer);
 
+    // Deploy the drop / edition
     vm.recordLogs();
-    factory.deployHolographableContract(config, signature, alice);
+    factory.deployHolographableContract(config, signature, alice); // Pass the payload hash, with the signature, and signer's address
     Vm.Log[] memory entries = vm.getRecordedLogs();
     address newDropAddress = address(uint160(uint256(entries[5].topics[1])));
     console.log("New drop address: ", newDropAddress);
 
-    // Test checks start here - Reenable when ready
+    // Test checks start here
     HolographERC721Drop drop = HolographERC721Drop(payable(newDropAddress));
     vm.startPrank(DEFAULT_FUNDS_RECIPIENT_ADDRESS);
     vm.deal(DEFAULT_FUNDS_RECIPIENT_ADDRESS, 10 ether);
@@ -259,15 +267,15 @@ contract HolographDropCreatorTest is Test {
   }
 
   function test_CreateHolographDrop() public {
-    // Setup sale config for open edition
+    // Setup sale config for drop
     IHolographERC721Drop.SalesConfiguration memory saleConfig = IHolographERC721Drop.SalesConfiguration({
-      publicSaleStart: 0,
-      publicSaleEnd: type(uint64).max,
-      presaleStart: 0,
-      presaleEnd: 0,
-      publicSalePrice: 0,
-      maxSalePurchasePerAddress: 0,
-      presaleMerkleRoot: bytes32(0)
+      publicSaleStart: 0, // starts now
+      publicSaleEnd: type(uint64).max, // never ends
+      presaleStart: 0, // never starts
+      presaleEnd: 0, // never ends
+      publicSalePrice: 0, // free
+      maxSalePurchasePerAddress: 0, // no limit
+      presaleMerkleRoot: bytes32(0) // no presale
     });
     bytes[] memory setupData = new bytes[](1);
     setupData[0] = abi.encodeWithSelector(
@@ -282,18 +290,18 @@ contract HolographDropCreatorTest is Test {
     );
     // Create initializer
     DropInitializer memory initializer = DropInitializer(
-      address(holographFeeManager), // HolographFeeManager,
+      address(feeManager), // HolographFeeManager,
       address(0), // HolographERC721TransferHelper
-      DEFAULT_HOLOGRAPH_DAO_ADDRESS,
-      name,
-      symbol,
-      defaultAdmin,
-      fundsRecipient,
-      editionSize,
-      royaltyBPS,
+      address(0), // marketFilterAddress
+      "Holograph ERC721 Drop Collection",
+      "hDROP",
+      payable(DEFAULT_OWNER_ADDRESS),
+      payable(DEFAULT_FUNDS_RECIPIENT_ADDRESS),
+      100,
+      1000,
       setupData,
       address(dropMetadataRenderer),
-      metadataInitializer
+      abi.encode("description", "imageURI", "animationURI")
     );
 
     // Get deployment config, hash it, and then sign it
@@ -313,20 +321,22 @@ contract HolographDropCreatorTest is Test {
     Verification memory signature = Verification(r, s, v);
     address signer = ecrecover(hash, v, r, s);
 
-    // Pass the payload hash, with the signature, and signer's address
+    // NOTE: This is the address of the HolographFactory that depends on a couple .env variables being set
+    //       Those variable are HOLOGRAPH_ENVIRONMENT="develop" and DEVELOP_DEPLOYMENT_SALT=1000
     HolographFactory factory = HolographFactory(payable(0x5Db4dB97fDfFB29cD85eA5484C3722095c413fc7));
     console.log("Factory address: ", address(factory));
     console.log("Holograph address: ", address(factory.getHolograph()));
     console.log("Registry address: ", address(factory.getRegistry()));
     console.log("Signer address: ", signer);
 
+    // Deploy the drop / edition
     vm.recordLogs();
-    factory.deployHolographableContract(config, signature, alice);
+    factory.deployHolographableContract(config, signature, alice); // Pass the payload hash, with the signature, and signer's address
     Vm.Log[] memory entries = vm.getRecordedLogs();
     address newDropAddress = address(uint160(uint256(entries[5].topics[1])));
     console.log("New drop address: ", newDropAddress);
 
-    // Test checks start here - Reenable when ready
+    // Test checks start here
     HolographERC721Drop drop = HolographERC721Drop(payable(newDropAddress));
     vm.startPrank(DEFAULT_FUNDS_RECIPIENT_ADDRESS);
     vm.deal(DEFAULT_FUNDS_RECIPIENT_ADDRESS, 10 ether);
@@ -334,8 +344,8 @@ contract HolographDropCreatorTest is Test {
     assertEq(drop.totalSupply(), 10);
   }
 
-  // HELPERS
-  function getDeploymentConfig(DropInitializer memory initializer) public returns (DeploymentConfig memory) {
+  // TEST HELPERS
+  function getDeploymentConfig(DropInitializer memory initializer) public pure returns (DeploymentConfig memory) {
     return
       DeploymentConfig({
         contractType: 0x00000000000000000000000000486F6C6F677261706845524337323144726F70, // HolographERC721Drop

--- a/test/forge/HolographDropCreator.t.sol
+++ b/test/forge/HolographDropCreator.t.sol
@@ -50,7 +50,7 @@ contract HolographDropCreatorTest is Test {
     // Setup VM
     // NOTE: These tests rely on the Holograph protocol being deployed to the local chain
     //       At the moment, the deploy pipeline is still managed by Hardhat, so we need to
-    //       first run it via `yarn deploy:localhost` or `npx hardhat deploy --network localhost` before running the tests.
+    //       first run it via `npx hardhat deploy --network localhost` or `yarn deploy:localhost` if you need two local chains before running the tests.
     uint256 forkId = vm.createFork("http://localhost:8545");
     vm.selectFork(forkId);
 
@@ -242,6 +242,7 @@ contract HolographDropCreatorTest is Test {
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hash);
     Verification memory signature = Verification(r, s, v);
     address signer = ecrecover(hash, v, r, s);
+    require(signer == alice, "Invalid signature");
 
     // NOTE: This is the address of the HolographFactory that depends on a couple .env variables being set
     //       Those variable are HOLOGRAPH_ENVIRONMENT="develop" and DEVELOP_DEPLOYMENT_SALT=1000

--- a/test/forge/HolographERC721Drop.t.sol
+++ b/test/forge/HolographERC721Drop.t.sol
@@ -87,6 +87,9 @@ contract HolographERC721DropTest is Test {
     // TODO: We might have to deploy two different drops enforcers (one for drops and one for editions) because the metadataRendererInit is different
     //       For drops it uses "metadata_uri", "metadata_contract_uri"
     //       For editions it uses imageURI, animationURI, description
+    //       The data is either encoded as  bytes memory metadataInitializer = abi.encode(metadataURIBase, metadataContractURI) or
+    //       bytes memory metadataInitializer = abi.encode("description", "imageURI", "animationURI")
+    //       depending on if it's a drop or edition
     DropInitializer memory initializer = DropInitializer({
       holographFeeManager: address(feeManager),
       holographERC721TransferHelper: address(0x1234),

--- a/test/forge/HolographERC721Drop.t.sol
+++ b/test/forge/HolographERC721Drop.t.sol
@@ -201,77 +201,77 @@ contract HolographERC721DropTest is Test {
     dropMetadataRenderer = new DropMetadataRenderer();
   }
 
-  // function test_DeployHolographDrop() public {
-  //   // Setup sale config for edition
-  //   IHolographERC721Drop.SalesConfiguration memory saleConfig = IHolographERC721Drop.SalesConfiguration({
-  //     publicSaleStart: 0, // starts now
-  //     publicSaleEnd: type(uint64).max, // never ends
-  //     presaleStart: 0, // never starts
-  //     presaleEnd: 0, // never ends
-  //     publicSalePrice: 0.1 ether, // 0.1 ETH
-  //     maxSalePurchasePerAddress: 0, // no limit
-  //     presaleMerkleRoot: bytes32(0) // no presale
-  //   });
-  //   bytes[] memory setupData = new bytes[](1);
-  //   setupData[0] = abi.encodeWithSelector(
-  //     HolographERC721Drop.setSaleConfiguration.selector,
-  //     saleConfig.publicSalePrice,
-  //     saleConfig.maxSalePurchasePerAddress,
-  //     saleConfig.publicSaleStart,
-  //     saleConfig.publicSaleEnd,
-  //     saleConfig.presaleStart,
-  //     saleConfig.presaleEnd,
-  //     saleConfig.presaleMerkleRoot
-  //   );
+  function test_DeployHolographDrop() public {
+    // Setup sale config for edition
+    IHolographERC721Drop.SalesConfiguration memory saleConfig = IHolographERC721Drop.SalesConfiguration({
+      publicSaleStart: 0, // starts now
+      publicSaleEnd: type(uint64).max, // never ends
+      presaleStart: 0, // never starts
+      presaleEnd: 0, // never ends
+      publicSalePrice: 0.1 ether, // 0.1 ETH
+      maxSalePurchasePerAddress: 0, // no limit
+      presaleMerkleRoot: bytes32(0) // no presale
+    });
+    bytes[] memory setupData = new bytes[](1);
+    setupData[0] = abi.encodeWithSelector(
+      HolographERC721Drop.setSaleConfiguration.selector,
+      saleConfig.publicSalePrice,
+      saleConfig.maxSalePurchasePerAddress,
+      saleConfig.publicSaleStart,
+      saleConfig.publicSaleEnd,
+      saleConfig.presaleStart,
+      saleConfig.presaleEnd,
+      saleConfig.presaleMerkleRoot
+    );
 
-  //   // Create initializer
-  //   DropInitializer memory initializer = DropInitializer(
-  //     address(feeManager), // HolographFeeManager,
-  //     address(0), // HolographERC721TransferHelper
-  //     address(0), // marketFilterAddress
-  //     "Holograph ERC721 Drop Collection",
-  //     "hDROP",
-  //     payable(DEFAULT_OWNER_ADDRESS),
-  //     payable(DEFAULT_FUNDS_RECIPIENT_ADDRESS),
-  //     100,
-  //     1000,
-  //     setupData,
-  //     address(dropMetadataRenderer),
-  //     abi.encode("description", "imageURI", "animationURI")
-  //   );
+    // Create initializer
+    DropInitializer memory initializer = DropInitializer(
+      address(feeManager), // HolographFeeManager,
+      address(0), // HolographERC721TransferHelper
+      address(0), // marketFilterAddress
+      "Holograph ERC721 Drop Collection",
+      "hDROP",
+      payable(DEFAULT_OWNER_ADDRESS),
+      payable(DEFAULT_FUNDS_RECIPIENT_ADDRESS),
+      100,
+      1000,
+      setupData,
+      address(dropMetadataRenderer),
+      abi.encode("description", "imageURI", "animationURI")
+    );
 
-  //   // Get deployment config, hash it, and then sign it
-  //   DeploymentConfig memory config = getDeploymentConfig(initializer);
-  //   bytes32 hash = keccak256(
-  //     abi.encodePacked(
-  //       config.contractType,
-  //       config.chainType,
-  //       config.salt,
-  //       keccak256(config.byteCode),
-  //       keccak256(config.initCode),
-  //       alice
-  //     )
-  //   );
+    // Get deployment config, hash it, and then sign it
+    DeploymentConfig memory config = getDeploymentConfig(initializer);
+    bytes32 hash = keccak256(
+      abi.encodePacked(
+        config.contractType,
+        config.chainType,
+        config.salt,
+        keccak256(config.byteCode),
+        keccak256(config.initCode),
+        alice
+      )
+    );
 
-  //   (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hash);
-  //   Verification memory signature = Verification(r, s, v);
-  //   address signer = ecrecover(hash, v, r, s);
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hash);
+    Verification memory signature = Verification(r, s, v);
+    address signer = ecrecover(hash, v, r, s);
 
-  //   // NOTE: This is the address of the HolographFactory that depends on a couple .env variables being set
-  //   //       Those variable are HOLOGRAPH_ENVIRONMENT="develop" and DEVELOP_DEPLOYMENT_SALT=1000
-  //   HolographFactory factory = HolographFactory(payable(0x5Db4dB97fDfFB29cD85eA5484C3722095c413fc7));
-  //   console.log("Factory address: ", address(factory));
-  //   console.log("Holograph address: ", address(factory.getHolograph()));
-  //   console.log("Registry address: ", address(factory.getRegistry()));
-  //   console.log("Signer address: ", signer);
+    // NOTE: This is the address of the HolographFactory that depends on a couple .env variables being set
+    //       Those variable are HOLOGRAPH_ENVIRONMENT="develop" and DEVELOP_DEPLOYMENT_SALT=1000
+    HolographFactory factory = HolographFactory(payable(0x5Db4dB97fDfFB29cD85eA5484C3722095c413fc7));
+    console.log("Factory address: ", address(factory));
+    console.log("Holograph address: ", address(factory.getHolograph()));
+    console.log("Registry address: ", address(factory.getRegistry()));
+    console.log("Signer address: ", signer);
 
-  //   // Deploy the drop / edition
-  //   vm.recordLogs();
-  //   factory.deployHolographableContract(config, signature, alice); // Pass the payload hash, with the signature, and signer's address
-  //   Vm.Log[] memory entries = vm.getRecordedLogs();
-  //   address newDropAddress = address(uint160(uint256(entries[5].topics[1])));
-  //   console.log("New drop address: ", newDropAddress);
-  // }
+    // Deploy the drop / edition
+    vm.recordLogs();
+    factory.deployHolographableContract(config, signature, alice); // Pass the payload hash, with the signature, and signer's address
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    address newDropAddress = address(uint160(uint256(entries[5].topics[1])));
+    console.log("New drop address: ", newDropAddress);
+  }
 
   function test_Init() public setupTestDrop(10) {
     require(erc721Drop.owner() == DEFAULT_OWNER_ADDRESS, "Default owner set wrong");

--- a/test/forge/HolographERC721DropUpgrades.t.sol
+++ b/test/forge/HolographERC721DropUpgrades.t.sol
@@ -19,7 +19,7 @@ contract HolographERC721DropTest is Test {
   HolographFeeManager public feeManager;
   address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
   address payable public constant DEFAULT_FUNDS_RECIPIENT_ADDRESS = payable(address(0x21303));
-  address payable public constant DEFAULT_HOLOGRAPH_DAO_ADDRESS = payable(address(0x999));
+  address payable public constant HOLOGRAPH_TREASURY_ADDRESS = payable(address(0x999));
   address public constant mediaContract = address(0x123456);
 
   function setUp() public {}

--- a/test/forge/merkle/MerkleDrop.t.sol
+++ b/test/forge/merkle/MerkleDrop.t.sol
@@ -17,7 +17,7 @@
 //   MerkleData public merkleData;
 //   address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
 //   address payable public constant DEFAULT_FUNDS_RECIPIENT_ADDRESS = payable(address(0x21303));
-//   address payable public constant DEFAULT_HOLOGRAPH_DAO_ADDRESS = payable(address(0x999));
+//   address payable public constant HOLOGRAPH_TREASURY_ADDRESS = payable(address(0x999));
 //   address public constant mediaContract = address(0x123456);
 
 //   // Drop properties
@@ -52,9 +52,9 @@
 //   }
 
 //   function setUp() public {
-//     vm.prank(DEFAULT_HOLOGRAPH_DAO_ADDRESS);
-//     holographFeeManager = new HolographFeeManager(250, DEFAULT_HOLOGRAPH_DAO_ADDRESS);
-//     vm.prank(DEFAULT_HOLOGRAPH_DAO_ADDRESS);
+//     vm.prank(HOLOGRAPH_TREASURY_ADDRESS);
+//     holographFeeManager = new HolographFeeManager(250, HOLOGRAPH_TREASURY_ADDRESS);
+//     vm.prank(HOLOGRAPH_TREASURY_ADDRESS);
 
 //     address impl = address(new ERC721Drop(feeManager, address(1234), FactoryUpgradeGate(address(0)), address(0)));
 //     address payable newDrop = payable(address(new HolographERC721DropProxy(impl, "")));

--- a/test/forge/utils/DummyMetadataRenderer.sol
+++ b/test/forge/utils/DummyMetadataRenderer.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.13;
 import {IMetadataRenderer} from "../../../contracts/drops/interfaces/IMetadataRenderer.sol";
 
 contract DummyMetadataRenderer is IMetadataRenderer {
+  string public someState;
+
   function tokenURI(uint256) external pure override returns (string memory) {
     return "DUMMY";
   }
@@ -14,5 +16,10 @@ contract DummyMetadataRenderer is IMetadataRenderer {
 
   function initializeWithData(bytes memory data) external {
     // no-op
+  }
+
+  function updateSomeState(string memory someStateNewValue, address expectedSender) external {
+    require(msg.sender == expectedSender);
+    someState = someStateNewValue;
   }
 }


### PR DESCRIPTION
## Describe Changes

- Updated HolographERC721Drop tests to use `deployHolographableContract`
- Added more notes / cleaned up some confusing code
- Switch from dummy metadata render to mock metadata renderer for tests
- Optimize filter registry performance for mint

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code styles have been enforced
- [ ] All Hardhat tests are passing
