### PR TITLE
Override version of yargs unparser for security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,5 +97,10 @@
     "ts-node": "^10.1.0",
     "typechain": "^7.0.0",
     "typescript": "^4.3.5"
+  },
+  "overrides": {
+    "hardhat-gas-reporter": {
+      "yargs-unparser": "2.0.0"
+    }
   }
 }


### PR DESCRIPTION
## Describe Changes

- Want to override yargs unparser version due to detected vulnerability
![image](https://user-images.githubusercontent.com/1504794/220236898-13d99fdd-ba31-4a8e-a546-df1931fb9feb.png)
- See https://github.com/holographxyz/holograph-protocol/security/dependabot/28

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code styles have been enforced
- [ ] All Hardhat tests are passing
