### PR TITLE
Fix HolographOperator security issue

### DIFF
--- a/src/HolographOperator.sol
+++ b/src/HolographOperator.sol
@@ -497,10 +497,7 @@ contract HolographOperator is Admin, Initializable, HolographOperatorInterface {
    * @dev This function is restricted for use by Holograph Messaging Module only
    */
   function crossChainMessage(bytes calldata bridgeInRequestPayload) external payable {
-    require(
-      msg.sender == address(_messagingModule()) || msg.sender == 0x777C19834a1A2FF6353a1E9cfb7C799ed7943a11,
-      "HOLOGRAPH: messaging only call"
-    );
+    require(msg.sender == address(_messagingModule()), "HOLOGRAPH: messaging only call");
     uint256 gasPrice = 0;
     assembly {
       /**


### PR DESCRIPTION
**Removing static messaging module address, which is related to Holograph V1 and should not have access to Holograph V2 under any circumstances.**

## Describe Changes

I made this more better by doing ...

- Removed static reference to `0x777C19834a1A2FF6353a1E9cfb7C799ed7943a11` which is a `LayerZeroModuleProxy` contract from **Holograph V1** and should not have access to **Holograph V2**.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] All Hardhat tests are passing
