### PR TITLE
Rewrite 10 holograph tests

### DIFF
--- a/test/foundry/deploy/10_holograph_tests.t.sol
+++ b/test/foundry/deploy/10_holograph_tests.t.sol
@@ -5,11 +5,7 @@ import {Test, Vm, console} from "forge-std/Test.sol";
 import {Constants} from "../utils/Constants.sol";
 import {Holograph} from "../../../src/Holograph.sol";
 import {MockExternalCall} from "../../../src/mock/MockExternalCall.sol";
-import {HolographInterface} from "../../../src/interface/HolographInterface.sol";
-
 contract HolographTests is Test {
-    uint256 localHostFork;
-    string LOCALHOST_RPC_URL = vm.envString("LOCALHOST_RPC_URL");
     address admin = vm.addr(1);
     address user = vm.addr(2);
     uint256 privateKeyDeployer = 0xff22437ccbedfffafa93a9f1da2e8c19c1711052799acf3b58ae5bebb5c6bd7b;
@@ -27,7 +23,6 @@ contract HolographTests is Test {
 
     Holograph holograph;
     MockExternalCall mockExternalCall;
-    HolographInterface holographInterface;
 
     function randomAddress() public view returns (address) {
         uint256 randomNum = uint256(keccak256(abi.encodePacked(block.timestamp, block.difficulty)));
@@ -35,7 +30,6 @@ contract HolographTests is Test {
     }
 
     function setUp() public {
-    localHostFork = vm.createFork(LOCALHOST_RPC_URL);
     
     // Deploy contracts
     vm.startPrank(deployer);
@@ -97,11 +91,11 @@ contract HolographTests is Test {
     GET BRIDGE
 */
 
-    function testReturnValidBridge() public {
+    function testReturnValid_bridgeSlot() public {
         assertEq(holograph.getBridge(), bridge);
     }
 
-    function testAllowExternalContract() public {
+    function testAllowExternalContractToCallGetBridge() public {
         bytes memory  encodeSignature = abi.encodeWithSignature('getBridge()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
     }
@@ -131,11 +125,11 @@ contract HolographTests is Test {
 */
 
     function testReturnValid_chainIdSlot() public {
-        //TODO ChainId vació es igualo a ChainId = 0 ??
+        //TODO Empty ChainId equals ChainId = 0 ??
         assertNotEq(holograph.getChainId(), 0);
     }
 
-    function testAllowExternalContractToCallFnGethainID() public {
+    function testAllowExternalContractToCallGetChainID() public {
         bytes memory  encodeSignature = abi.encodeWithSignature('getChainId()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);        
     }
@@ -168,7 +162,7 @@ contract HolographTests is Test {
         assertEq(holograph.getFactory(), factory);
     }
 
-    function testAllowExternalContractToCallFnGetFactory() public {
+    function testAllowExternalContractToCallGetFactory() public {
         bytes memory  encodeSignature = abi.encodeWithSignature('getFactory()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
     }
@@ -201,7 +195,7 @@ contract HolographTests is Test {
         assertEq(holograph.getHolographChainId(), holographChainId);
     }
 
-    function testAllowExternalContractToCallFnGetHolographChainId() public {
+    function testAllowExternalContractToCallGetHolographChainId() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getHolographChainId()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
     }
@@ -234,7 +228,7 @@ contract HolographTests is Test {
         assertEq(holograph.getInterfaces(), interfaces);
     }
 
-    function testAllowExternalContractToCallFnGetInterfaces() public {
+    function testAllowExternalContractToCallGetInterfaces() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getInterfaces()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
     }    
@@ -267,7 +261,7 @@ contract HolographTests is Test {
         assertEq(holograph.getOperator(), operator);
     }
 
-    function testAllowExternalContractToCallFnGetOperator() public {
+    function testAllowExternalContractToCallGetOperator() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getOperator()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
     }
@@ -300,7 +294,7 @@ contract HolographTests is Test {
         assertEq(holograph.getRegistry(), registry);
     }
 
-    function testAllowExternalContractToCallFnGetRegistry() public {
+    function testAllowExternalContractToCallGetRegistry() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getRegistry()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
     }
@@ -333,7 +327,7 @@ contract HolographTests is Test {
         assertEq(holograph.getTreasury(), treasury);
     }
 
-    function testAllowExternalContractToCallFnGetTreasury() public {
+    function testAllowExternalContractToCallGetTreasury() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getTreasury()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
     }
@@ -366,7 +360,7 @@ contract HolographTests is Test {
         assertEq(holograph.getTreasury(), treasury);
     }
 
-    function testAllowExternalContractToCallFnGetUtilityToken() public {
+    function testAllowExternalContractToCallGetUtilityToken() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getUtilityToken()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
     }

--- a/test/foundry/deploy/10_holograph_tests.t.sol
+++ b/test/foundry/deploy/10_holograph_tests.t.sol
@@ -5,6 +5,18 @@ import {Test, Vm, console} from "forge-std/Test.sol";
 import {Constants} from "../utils/Constants.sol";
 import {Holograph} from "../../../src/Holograph.sol";
 import {MockExternalCall} from "../../../src/mock/MockExternalCall.sol";
+
+    /**
+    * @title Contract Test - Holograph
+    * @notice This contract contains a series of tests to verify the functionality of the Holograph contract.
+    * The tests cover the initialization process, getter functions, and setter functions.
+    * @dev The tests include verifying initialization, admin functions, revert behaviors, and external contract interactions.
+    * The tests check the validity of various contract slots like bridge, chainId, factory, interfaces, operator, registry, 
+    * treasury, and utilityToken.
+    * The tests also verify that only the admin can alter certain contract slots, while non-owners trigger revert behaviors.
+    * Translation of a suite of Hardhat tests found in test/10_holograph_tests.ts
+    */
+
 contract HolographTests is Test {
     address admin = vm.addr(1);
     address user = vm.addr(2);
@@ -69,6 +81,12 @@ contract HolographTests is Test {
     INIT()
 */
 
+    /**
+    * @notice Test the initialization of the Holograph contract.
+    * @dev This is a basic test to ensure the initialization process works as expected.
+    * This test deploys a new instance of the Holograph contract, generates initialization code,
+    * and initializes the contract with the provided parameters.
+    */
     function testInit() public {
         Holograph holographTest;
         holographTest = new Holograph();
@@ -76,12 +94,26 @@ contract HolographTests is Test {
         holographTest.init(initCode);
     }
 
+    /**
+    * @notice Test the setAdmin function of the Holograph contract.
+    * @dev This test is designed to verify the functionality of setting a new admin address in the contract.
+    * This test retrieves the current admin address from the Holograph contract,
+    * performs a prank operation on the admin address using the VM,
+    * and then sets a new admin address to the contract.
+    */
+    // TODO Admin does not correspond to the address that performs the init
     function testSetAdmin() public {
         admin = holograph.getAdmin();
         vm.prank(admin);
         holograph.setAdmin(user);
     }
 
+    /**
+    * @notice Test the revert behavior when trying to initialize an already initialized Holograph contract.
+    * @dev This test is designed to verify that the contract reverts as expected when the contract has already been initialized.
+    * This test expects a revert with the message 'HOLOGRAPH: already initialized' when trying to initialize
+    * a Holograph contract that is already initialized.
+    */
     function testInitAlreadyInitializedRevert() public {
         vm.expectRevert('HOLOGRAPH: already initialized');
         holograph.init(initCode);
@@ -91,10 +123,23 @@ contract HolographTests is Test {
     GET BRIDGE
 */
 
+    /**
+    * @notice Test the validity of the bridge slot in the Holograph contract.
+    * @dev This test is designed to ensure the correct functionality of the bridge slot in the contract.
+    * This test verifies that the value returned by `getBridge()` in the Holograph contract
+    * matches the expected `bridge` address.
+    */
     function testReturnValid_bridgeSlot() public {
         assertEq(holograph.getBridge(), bridge);
     }
 
+    /**
+    * @notice Test the ability of an external contract to call the getBridge function in the Holograph contract.
+    * @dev This test is designed to verify that an external contract can successfully call the getBridge 
+    * function in the Holograph contract.
+    * This test encodes the signature of the getBridge function and calls it from an external contract 
+    * using mockExternalCall.
+    */
     function testAllowExternalContractToCallGetBridge() public {
         bytes memory  encodeSignature = abi.encodeWithSignature('getBridge()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
@@ -104,16 +149,34 @@ contract HolographTests is Test {
     SET BRIDGE
 */
 
+    /**
+    * @notice Test the ability of the admin to alter the bridge slot in the Holograph contract.
+    * @dev This test is designed to verify that the admin can alter the bridge slot in the contract.
+    * This test performs a prank operation on the current admin address of the Holograph contract,
+    * and then sets a new random address as the bridge in the contract.
+    */
     function testAllowAdminAlter_bridgeSlot() public {
         vm.prank(holograph.admin());
         holograph.setBridge(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when the owner tries to alter the bridge slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the bridge slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when the owner attempts to
+    * alter the bridge slot in the Holograph contract.
+    */
     function testAllowOwnerToAlter_bridgeSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         holograph.setBridge(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when a non-owner tries to alter the bridge slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the bridge slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when a non-owner attempts to
+    * alter the bridge slot in the Holograph contract.
+    */
     function testAllowNonOwnerToAlter_bridgeSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         vm.prank(user);
@@ -124,11 +187,24 @@ contract HolographTests is Test {
     GET CHAINID
 */
 
+    /**
+    * @notice Test the validity of the chainId slot in the Holograph contract.
+    * @dev This test is designed to ensure the correct functionality of the chainId slot in the contract. 
+    * This test verifies that the value returned by `getChainId()` in the Holograph contract
+    * is not equal to zero.
+    */
     function testReturnValid_chainIdSlot() public {
         //TODO Empty ChainId equals ChainId = 0 ??
         assertNotEq(holograph.getChainId(), 0);
     }
 
+    /**
+    * @notice Test the ability of an external contract to call the getChainId function in the Holograph contract.
+    * @dev This test is designed to verify that an external contract can successfully call the getChainId 
+    * function in the Holograph contract.
+    * This test encodes the signature of the getChainId function and calls it from an external contract 
+    * using mockExternalCall.
+    */
     function testAllowExternalContractToCallGetChainID() public {
         bytes memory  encodeSignature = abi.encodeWithSignature('getChainId()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);        
@@ -138,16 +214,34 @@ contract HolographTests is Test {
     SET CHAIN ID
 */
 
+    /**
+    * @notice Test the ability of the admin to alter the chainId slot in the Holograph contract.
+    * @dev This test is designed to verify that the admin can alter the chainId slot in the contract.
+    * This test performs a prank operation on the current admin address of the Holograph contract,
+    * and then sets a new random address as the chainId in the contract.
+    */
     function testAllowAdminAlter_chainIdSlot() public {
         vm.prank(holograph.admin());
         holograph.setChainId((2));
     }
 
+    /**
+    * @notice Test the revert behavior when the owner tries to alter the chainId slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the chainId slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when the owner attempts to
+    * alter the chainId slot in the Holograph contract.
+    */
     function testAllowOwnerAlter_chainIdSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         holograph.setChainId(3);
     }
 
+    /**
+    * @notice Test the revert behavior when a non-owner tries to alter the chainId slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the chainId slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when a non-owner attempts to
+    * alter the chainId slot in the Holograph contract.
+    */
     function testAllowNonOwnerAlter_chainIdSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         vm.prank(user);
@@ -158,10 +252,23 @@ contract HolographTests is Test {
     GET FACTORY
 */
 
+    /**
+    * @notice Test the validity of the factory slot in the Holograph contract.
+    * @dev This test is designed to ensure the correct functionality of the factory slot in the contract.
+    * This test verifies that the value returned by `getFactory()` in the Holograph contract
+    * matches the expected `factory` address.
+    */
     function testReturnValid_factorySlot() public {
         assertEq(holograph.getFactory(), factory);
     }
 
+    /**
+    * @notice Test the ability of an external contract to call the getFactory function in the Holograph contract.
+    * @dev This test is designed to verify that an external contract can successfully call the getFactory 
+    * function in the Holograph contract.
+    * This test encodes the signature of the getFactory function and calls it from an external contract 
+    * using mockExternalCall.
+    */
     function testAllowExternalContractToCallGetFactory() public {
         bytes memory  encodeSignature = abi.encodeWithSignature('getFactory()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
@@ -171,16 +278,34 @@ contract HolographTests is Test {
     SET FACTORY
 */
 
-    function testAllowAdminAlter_factoryIdSlot() public {
+    /**
+    * @notice Test the ability of the admin to alter the factory slot in the Holograph contract.
+    * @dev This test is designed to verify that the admin can alter the factory slot in the contract.
+    * This test performs a prank operation on the current admin address of the Holograph contract,
+    * and then sets a new random address as the factory in the contract.
+    */
+    function testAllowAdminAlter_factorySlot() public {
         vm.prank(holograph.admin());
         holograph.setFactory(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when the owner tries to alter the factory slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the factory slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when the owner attempts to
+    * alter the factory slot in the Holograph contract.
+    */
     function testAllowOwnerAlter_factorySlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         holograph.setFactory(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when a non-owner tries to alter the factory slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the factory slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when a non-owner attempts to
+    * alter the factory slot in the Holograph contract.
+    */
     function testAllowNonOwnerAlter_factorySlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         vm.prank(user);
@@ -191,10 +316,23 @@ contract HolographTests is Test {
     GET HOLOGRAPH CHAINID
 */
 
+    /**
+    * @notice Test the validity of the holographChainId slot in the Holograph contract.
+    * @dev This test is designed to ensure the correct functionality of the holographChainId slot in the contract.
+    * This test verifies that the value returned by `getHolographChainId()` in the Holograph contract
+    * matches the expected `holographChainId` address.
+    */
     function testReturnValid_holographChainIdSlot() public {
         assertEq(holograph.getHolographChainId(), holographChainId);
     }
 
+    /**
+    * @notice Test the ability of an external contract to call the getHolographChainId function in the Holograph contract.
+    * @dev This test is designed to verify that an external contract can successfully call the getHolographChainId 
+    * function in the Holograph contract.
+    * This test encodes the signature of the getHolographChainId function and calls it from an external contract 
+    * using mockExternalCall.
+    */
     function testAllowExternalContractToCallGetHolographChainId() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getHolographChainId()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
@@ -204,16 +342,34 @@ contract HolographTests is Test {
     SET HOLOGRAPH CHAINID
 */
 
+    /**
+    * @notice Test the ability of the admin to alter the holographChainId slot in the Holograph contract.
+    * @dev This test is designed to verify that the admin can alter the holographChainId slot in the contract.
+    * This test performs a prank operation on the current admin address of the Holograph contract,
+    * and then sets a new random address as the holographChainId in the contract.
+    */
     function testAllowAdminAlter_holographChainIdSlot() public {
         vm.prank(holograph.admin());
         holograph.setHolographChainId(2);
     }
 
+    /**
+    * @notice Test the revert behavior when the owner tries to alter the holographChainId slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the holographChainId slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when the owner attempts to
+    * alter the holographChainId slot in the Holograph contract.
+    */
     function testAllowOwnerAlter_holographChainIdSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         holograph.setHolographChainId(3);
     }
 
+    /**
+    * @notice Test the revert behavior when a non-owner tries to alter the holographChainId slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the holographChainId slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when a non-owner attempts to
+    * alter the holographChainId slot in the Holograph contract.
+    */
     function testAllowNonOwnerAlter_holographChainIdSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         vm.prank(user);
@@ -224,10 +380,23 @@ contract HolographTests is Test {
     GET INTERFACES
 */
 
+    /**
+    * @notice Test the validity of the interfaces slot in the Holograph contract.
+    * @dev This test is designed to ensure the correct functionality of the interfaces slot in the contract.
+    * This test verifies that the value returned by `getInterfaces()` in the Holograph contract
+    * matches the expected `interfaces` address.
+    */
     function testReturnValid_interfacesSlot() public {
         assertEq(holograph.getInterfaces(), interfaces);
     }
 
+    /**
+    * @notice Test the ability of an external contract to call the getInterfaces function in the Holograph contract.
+    * @dev This test is designed to verify that an external contract can successfully call the getInterfaces 
+    * function in the Holograph contract.
+    * This test encodes the signature of the getInterfaces function and calls it from an external contract 
+    * using mockExternalCall.
+    */
     function testAllowExternalContractToCallGetInterfaces() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getInterfaces()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
@@ -237,16 +406,34 @@ contract HolographTests is Test {
     SET INTERFACES
 */
 
+    /**
+    * @notice Test the ability of the admin to alter the interfaces slot in the Holograph contract.
+    * @dev This test is designed to verify that the admin can alter the interfaces slot in the contract.
+    * This test performs a prank operation on the current admin address of the Holograph contract,
+    * and then sets a new random address as the interfaces in the contract.
+    */
     function testAllowAdminAlter_interfacesSlot() public {
         vm.prank(holograph.admin());
         holograph.setInterfaces(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when the owner tries to alter the interfaces slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the interfaces slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when the owner attempts to
+    * alter the interfaces slot in the Holograph contract.
+    */
     function testAllowOwnerAlter_interfacesSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         holograph.setInterfaces(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when a non-owner tries to alter the interfaces slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the interfaces slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when a non-owner attempts to
+    * alter the interfaces slot in the Holograph contract.
+    */
     function testAllowNonOwnerAlter_interfacesSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         vm.prank(user);
@@ -257,10 +444,23 @@ contract HolographTests is Test {
     GET OPERATOR
 */
 
+    /**
+    * @notice Test the validity of the operator slot in the Holograph contract.
+    * @dev This test is designed to ensure the correct functionality of the operator slot in the contract.
+    * This test verifies that the value returned by `getOperator()` in the Holograph contract
+    * matches the expected `operator` address.
+    */
     function testReturnValid_operatorSlot() public {
         assertEq(holograph.getOperator(), operator);
     }
 
+    /**
+    * @notice Test the ability of an external contract to call the getOperator function in the Holograph contract.
+    * @dev This test is designed to verify that an external contract can successfully call the getOperator 
+    * function in the Holograph contract.
+    * This test encodes the signature of the getOperator function and calls it from an external contract 
+    * using mockExternalCall.
+    */
     function testAllowExternalContractToCallGetOperator() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getOperator()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
@@ -270,16 +470,34 @@ contract HolographTests is Test {
     SET OPERATOR
 */
 
+    /**
+    * @notice Test the ability of the admin to alter the operator slot in the Holograph contract.
+    * @dev This test is designed to verify that the admin can alter the operator slot in the contract.
+    * This test performs a prank operation on the current admin address of the Holograph contract,
+    * and then sets a new random address as the operator in the contract.
+    */
     function testAllowAdminAlter_operatorSlot() public {
         vm.prank(holograph.admin());
         holograph.setOperator(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when the owner tries to alter the operator slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the operator slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when the owner attempts to
+    * alter the operator slot in the Holograph contract.
+    */
     function testAllowOwnerAlter_operatorSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         holograph.setOperator(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when a non-owner tries to alter the operator slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the operator slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when a non-owner attempts to
+    * alter the operator slot in the Holograph contract.
+    */
     function testAllowNonOwnerAlter_operatorSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         vm.prank(user);
@@ -290,10 +508,23 @@ contract HolographTests is Test {
     GET REGISTRY
 */
 
+    /**
+    * @notice Test the validity of the registry slot in the Holograph contract.
+    * @dev This test is designed to ensure the correct functionality of the registry slot in the contract.
+    * This test verifies that the value returned by `getRegistry()` in the Holograph contract
+    * matches the expected `registry` address.
+    */
     function testReturnValid_registrySlot() public {
         assertEq(holograph.getRegistry(), registry);
     }
 
+    /**
+    * @notice Test the ability of an external contract to call the getRegistry function in the Holograph contract.
+    * @dev This test is designed to verify that an external contract can successfully call the getRegistry 
+    * function in the Holograph contract.
+    * This test encodes the signature of the getRegistry function and calls it from an external contract 
+    * using mockExternalCall.
+    */
     function testAllowExternalContractToCallGetRegistry() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getRegistry()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
@@ -303,16 +534,34 @@ contract HolographTests is Test {
     SET REGISTRY
 */
 
+    /**
+    * @notice Test the ability of the admin to alter the registry slot in the Holograph contract.
+    * @dev This test is designed to verify that the admin can alter the registry slot in the contract.
+    * This test performs a prank operation on the current admin address of the Holograph contract,
+    * and then sets a new random address as the registry in the contract.
+    */
     function testAllowAdminAlter_registrySlot() public {
         vm.prank(holograph.admin());
         holograph.setRegistry(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when the owner tries to alter the registry slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the registry slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when the owner attempts to
+    * alter the registry slot in the Holograph contract.
+    */
     function testAllowOwnerAlter_registrySlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         holograph.setRegistry(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when a non-owner tries to alter the registry slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the registry slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when a non-owner attempts to
+    * alter the registry slot in the Holograph contract.
+    */
     function testAllowNonOwnerAlter_registrySlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         vm.prank(user);
@@ -323,10 +572,23 @@ contract HolographTests is Test {
     GET TREASURY
 */
 
+    /**
+    * @notice Test the validity of the treasury slot in the Holograph contract.
+    * @dev This test is designed to ensure the correct functionality of the treasury slot in the contract.
+    * This test verifies that the value returned by `getTreasury()` in the Holograph contract
+    * matches the expected `treasury` address.
+    */
     function testReturnValid_treasurySlot() public {
         assertEq(holograph.getTreasury(), treasury);
     }
 
+    /**
+    * @notice Test the ability of an external contract to call the getTreasury function in the Holograph contract.
+    * @dev This test is designed to verify that an external contract can successfully call the getTreasury 
+    * function in the Holograph contract.
+    * This test encodes the signature of the getTreasury function and calls it from an external contract 
+    * using mockExternalCall.
+    */
     function testAllowExternalContractToCallGetTreasury() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getTreasury()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
@@ -336,16 +598,34 @@ contract HolographTests is Test {
     SET TREASURY
 */
 
+    /**
+    * @notice Test the ability of the admin to alter the treasury slot in the Holograph contract.
+    * @dev This test is designed to verify that the admin can alter the treasury slot in the contract.
+    * This test performs a prank operation on the current admin address of the Holograph contract,
+    * and then sets a new random address as the treasury in the contract.
+    */
     function testAllowAdminAlter_treasurySlot() public {
         vm.prank(holograph.admin());
         holograph.setTreasury(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when the owner tries to alter the treasury slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the treasury slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when the owner attempts to
+    * alter the treasury slot in the Holograph contract.
+    */
     function testAllowOwnerAlter_treasurySlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         holograph.setTreasury(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when a non-owner tries to alter the treasury slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the treasury slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when a non-owner attempts to
+    * alter the treasury slot in the Holograph contract.
+    */
     function testAllowNonOwnerAlter_treasurySlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         vm.prank(user);
@@ -356,10 +636,23 @@ contract HolographTests is Test {
     GET UTILITY TOKEN
 */
 
+    /**
+    * @notice Test the validity of the utilityToken slot in the Holograph contract.
+    * @dev This test is designed to ensure the correct functionality of the utilityToken slot in the contract.
+    * This test verifies that the value returned by `getUtilityToken()` in the Holograph contract
+    * matches the expected `utilityToken` address.
+    */
     function testReturnValid_utilityTokenSlot() public {
-        assertEq(holograph.getTreasury(), treasury);
+        assertEq(holograph.getUtilityToken(), utilityToken);
     }
 
+    /**
+    * @notice Test the ability of an external contract to call the getUtilityToken function in the Holograph contract.
+    * @dev This test is designed to verify that an external contract can successfully call the getUtilityToken 
+    * function in the Holograph contract.
+    * This test encodes the signature of the getUtilityToken function and calls it from an external contract 
+    * using mockExternalCall.
+    */
     function testAllowExternalContractToCallGetUtilityToken() public {
         bytes memory encodeSignature = abi.encodeWithSignature('getUtilityToken()');
         mockExternalCall.callExternalFn(address(holograph), encodeSignature);
@@ -369,16 +662,34 @@ contract HolographTests is Test {
     SET UTILITY TOKEN
 */
 
+    /**
+    * @notice Test the ability of the admin to alter the utilityToken slot in the Holograph contract.
+    * @dev This test is designed to verify that the admin can alter the utilityToken slot in the contract.
+    * This test performs a prank operation on the current admin address of the Holograph contract,
+    * and then sets a new random address as the utilityToken in the contract.
+    */
     function testAllowAdminAlter_utilityTokenSlot() public {
         vm.prank(holograph.admin());
         holograph.setUtilityToken(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when the owner tries to alter the utilityToken slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the utilityToken slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when the owner attempts to
+    * alter the utilityToken slot in the Holograph contract.
+    */
     function testAllowOwnerAlter_utilityTokenSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         holograph.setUtilityToken(randomAddress());
     }
 
+    /**
+    * @notice Test the revert behavior when a non-owner tries to alter the utilityToken slot in the Holograph contract.
+    * @dev This test is designed to verify that only the admin can alter the utilityToken slot in the contract.
+    * This test expects a revert with the message 'HOLOGRAPH: admin only function' when a non-owner attempts to
+    * alter the utilityToken slot in the Holograph contract.
+    */
     function testAllowNonOwnerAlter_utilityTokenSlotRevert() public {
         vm.expectRevert('HOLOGRAPH: admin only function');
         vm.prank(user);

--- a/test/foundry/deploy/10_holograph_tests.t.sol
+++ b/test/foundry/deploy/10_holograph_tests.t.sol
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.13;
+
+import {Test, Vm, console} from "forge-std/Test.sol";
+import {Constants} from "../utils/Constants.sol";
+import {Holograph} from "../../../src/Holograph.sol";
+import {MockExternalCall} from "../../../src/mock/MockExternalCall.sol";
+import {HolographInterface} from "../../../src/interface/HolographInterface.sol";
+
+contract HolographTests is Test {
+    uint256 localHostFork;
+    string LOCALHOST_RPC_URL = vm.envString("LOCALHOST_RPC_URL");
+    address admin = vm.addr(1);
+    address user = vm.addr(2);
+    uint256 privateKeyDeployer = 0xff22437ccbedfffafa93a9f1da2e8c19c1711052799acf3b58ae5bebb5c6bd7b;
+    address deployer = vm.addr(privateKeyDeployer);
+
+    bytes initCode;
+    uint32  holographChainId;
+    address bridge;
+    address factory;
+    address interfaces;
+    address operator;
+    address registry;
+    address treasury;
+    address utilityToken;
+
+    Holograph holograph;
+    MockExternalCall mockExternalCall;
+    HolographInterface holographInterface;
+
+    function randomAddress() public view returns (address) {
+        uint256 randomNum = uint256(keccak256(abi.encodePacked(block.timestamp, block.difficulty)));
+        return address(uint160(randomNum));
+    }
+
+    function setUp() public {
+    localHostFork = vm.createFork(LOCALHOST_RPC_URL);
+    
+    // Deploy contracts
+    vm.startPrank(deployer);
+    holograph = new Holograph();
+    mockExternalCall = new MockExternalCall();
+    vm.stopPrank();
+
+    holographChainId = 1;
+    bridge = randomAddress();
+    factory = randomAddress();
+    interfaces = randomAddress();
+    operator = randomAddress();
+    registry = randomAddress();
+    treasury = randomAddress();
+    utilityToken = randomAddress();
+
+    bytes memory initCode = generateInitCode(holographChainId, bridge, factory, interfaces, operator, registry, treasury, utilityToken);
+    holograph.init(initCode);
+    }
+
+    function generateInitCode(
+    uint32 holographChainId,
+    address bridge,
+    address factory,
+    address interfaces,
+    address operator,
+    address registry,
+    address treasury,
+    address utilityToken
+    ) public pure returns (bytes memory) {
+        return abi.encode(
+        holographChainId, bridge, factory, interfaces, operator, registry, treasury, utilityToken
+        );
+    }
+
+/*
+    INIT()
+*/
+
+    function testInit() public {
+        Holograph holographTest;
+        holographTest = new Holograph();
+        bytes memory initCode = generateInitCode(holographChainId, bridge, factory, interfaces, operator, registry, treasury, utilityToken);
+        holographTest.init(initCode);
+    }
+
+    function testSetAdmin() public {
+        admin = holograph.getAdmin();
+        vm.prank(admin);
+        holograph.setAdmin(user);
+    }
+
+    function testInitAlreadyInitializedRevert() public {
+        vm.expectRevert('HOLOGRAPH: already initialized');
+        holograph.init(initCode);
+    }
+
+/*
+    GET BRIDGE
+*/
+
+    function testReturnValidBridge() public {
+        assertEq(holograph.getBridge(), bridge);
+    }
+
+    function testAllowExternalContract() public {
+        bytes memory  encodeSignature = abi.encodeWithSignature('getBridge()');
+        mockExternalCall.callExternalFn(address(holograph), encodeSignature);
+    }
+
+/*
+    SET BRIDGE
+*/
+
+    function testAllowAdminAlter_bridgeSlot() public {
+        vm.prank(holograph.admin());
+        holograph.setBridge(randomAddress());
+    }
+
+    function testAllowOwnerToAlter_bridgeSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        holograph.setBridge(randomAddress());
+    }
+
+    function testAllowNonOwnerToAlter_bridgeSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        vm.prank(user);
+        holograph.setBridge(randomAddress());
+    }
+
+/*
+    GET CHAINID
+*/
+
+    function testReturnValid_chainIdSlot() public {
+        //TODO ChainId vació es igualo a ChainId = 0 ??
+        assertNotEq(holograph.getChainId(), 0);
+    }
+
+    function testAllowExternalContractToCallFnGethainID() public {
+        bytes memory  encodeSignature = abi.encodeWithSignature('getChainId()');
+        mockExternalCall.callExternalFn(address(holograph), encodeSignature);        
+    }
+
+/*
+    SET CHAIN ID
+*/
+
+    function testAllowAdminAlter_chainIdSlot() public {
+        vm.prank(holograph.admin());
+        holograph.setChainId((2));
+    }
+
+    function testAllowOwnerAlter_chainIdSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        holograph.setChainId(3);
+    }
+
+    function testAllowNonOwnerAlter_chainIdSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        vm.prank(user);
+        holograph.setChainId(4);
+    }
+
+/*
+    GET FACTORY
+*/
+
+    function testReturnValid_factorySlot() public {
+        assertEq(holograph.getFactory(), factory);
+    }
+
+    function testAllowExternalContractToCallFnGetFactory() public {
+        bytes memory  encodeSignature = abi.encodeWithSignature('getFactory()');
+        mockExternalCall.callExternalFn(address(holograph), encodeSignature);
+    }
+
+/*
+    SET FACTORY
+*/
+
+    function testAllowAdminAlter_factoryIdSlot() public {
+        vm.prank(holograph.admin());
+        holograph.setFactory(randomAddress());
+    }
+
+    function testAllowOwnerAlter_factorySlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        holograph.setFactory(randomAddress());
+    }
+
+    function testAllowNonOwnerAlter_factorySlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        vm.prank(user);
+        holograph.setFactory(randomAddress());
+    }
+
+/*
+    GET HOLOGRAPH CHAINID
+*/
+
+    function testReturnValid_holographChainIdSlot() public {
+        assertEq(holograph.getHolographChainId(), holographChainId);
+    }
+
+    function testAllowExternalContractToCallFnGetHolographChainId() public {
+        bytes memory encodeSignature = abi.encodeWithSignature('getHolographChainId()');
+        mockExternalCall.callExternalFn(address(holograph), encodeSignature);
+    }
+
+/*
+    SET HOLOGRAPH CHAINID
+*/
+
+    function testAllowAdminAlter_holographChainIdSlot() public {
+        vm.prank(holograph.admin());
+        holograph.setHolographChainId(2);
+    }
+
+    function testAllowOwnerAlter_holographChainIdSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        holograph.setHolographChainId(3);
+    }
+
+    function testAllowNonOwnerAlter_holographChainIdSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        vm.prank(user);
+        holograph.setHolographChainId(4);
+    }
+
+/*
+    GET INTERFACES
+*/
+
+    function testReturnValid_interfacesSlot() public {
+        assertEq(holograph.getInterfaces(), interfaces);
+    }
+
+    function testAllowExternalContractToCallFnGetInterfaces() public {
+        bytes memory encodeSignature = abi.encodeWithSignature('getInterfaces()');
+        mockExternalCall.callExternalFn(address(holograph), encodeSignature);
+    }    
+
+/*
+    SET INTERFACES
+*/
+
+    function testAllowAdminAlter_interfacesSlot() public {
+        vm.prank(holograph.admin());
+        holograph.setInterfaces(randomAddress());
+    }
+
+    function testAllowOwnerAlter_interfacesSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        holograph.setInterfaces(randomAddress());
+    }
+
+    function testAllowNonOwnerAlter_interfacesSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        vm.prank(user);
+        holograph.setInterfaces(randomAddress());
+    }
+
+/*
+    GET OPERATOR
+*/
+
+    function testReturnValid_operatorSlot() public {
+        assertEq(holograph.getOperator(), operator);
+    }
+
+    function testAllowExternalContractToCallFnGetOperator() public {
+        bytes memory encodeSignature = abi.encodeWithSignature('getOperator()');
+        mockExternalCall.callExternalFn(address(holograph), encodeSignature);
+    }
+
+/*
+    SET OPERATOR
+*/
+
+    function testAllowAdminAlter_operatorSlot() public {
+        vm.prank(holograph.admin());
+        holograph.setOperator(randomAddress());
+    }
+
+    function testAllowOwnerAlter_operatorSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        holograph.setOperator(randomAddress());
+    }
+
+    function testAllowNonOwnerAlter_operatorSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        vm.prank(user);
+        holograph.setOperator(randomAddress());
+    }
+
+/*
+    GET REGISTRY
+*/
+
+    function testReturnValid_registrySlot() public {
+        assertEq(holograph.getRegistry(), registry);
+    }
+
+    function testAllowExternalContractToCallFnGetRegistry() public {
+        bytes memory encodeSignature = abi.encodeWithSignature('getRegistry()');
+        mockExternalCall.callExternalFn(address(holograph), encodeSignature);
+    }
+
+/*
+    SET REGISTRY
+*/
+
+    function testAllowAdminAlter_registrySlot() public {
+        vm.prank(holograph.admin());
+        holograph.setRegistry(randomAddress());
+    }
+
+    function testAllowOwnerAlter_registrySlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        holograph.setRegistry(randomAddress());
+    }
+
+    function testAllowNonOwnerAlter_registrySlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        vm.prank(user);
+        holograph.setRegistry(randomAddress());
+    }
+
+/*
+    GET TREASURY
+*/
+
+    function testReturnValid_treasurySlot() public {
+        assertEq(holograph.getTreasury(), treasury);
+    }
+
+    function testAllowExternalContractToCallFnGetTreasury() public {
+        bytes memory encodeSignature = abi.encodeWithSignature('getTreasury()');
+        mockExternalCall.callExternalFn(address(holograph), encodeSignature);
+    }
+
+/*
+    SET TREASURY
+*/
+
+    function testAllowAdminAlter_treasurySlot() public {
+        vm.prank(holograph.admin());
+        holograph.setTreasury(randomAddress());
+    }
+
+    function testAllowOwnerAlter_treasurySlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        holograph.setTreasury(randomAddress());
+    }
+
+    function testAllowNonOwnerAlter_treasurySlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        vm.prank(user);
+        holograph.setTreasury(randomAddress());
+    }
+
+/*
+    GET UTILITY TOKEN
+*/
+
+    function testReturnValid_utilityTokenSlot() public {
+        assertEq(holograph.getTreasury(), treasury);
+    }
+
+    function testAllowExternalContractToCallFnGetUtilityToken() public {
+        bytes memory encodeSignature = abi.encodeWithSignature('getUtilityToken()');
+        mockExternalCall.callExternalFn(address(holograph), encodeSignature);
+    }
+
+/*
+    SET UTILITY TOKEN
+*/
+
+    function testAllowAdminAlter_utilityTokenSlot() public {
+        vm.prank(holograph.admin());
+        holograph.setUtilityToken(randomAddress());
+    }
+
+    function testAllowOwnerAlter_utilityTokenSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        holograph.setUtilityToken(randomAddress());
+    }
+
+    function testAllowNonOwnerAlter_utilityTokenSlotRevert() public {
+        vm.expectRevert('HOLOGRAPH: admin only function');
+        vm.prank(user);
+        holograph.setUtilityToken(randomAddress());
+    }
+
+}
+

--- a/test/foundry/deploy/10_holograph_tests.t.sol
+++ b/test/foundry/deploy/10_holograph_tests.t.sol
@@ -20,6 +20,7 @@ import {MockExternalCall} from "../../../src/mock/MockExternalCall.sol";
 contract HolographTests is Test {
     address admin = vm.addr(1);
     address user = vm.addr(2);
+    address origin = 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38;  //default address origin in foundry
     uint256 privateKeyDeployer = 0xff22437ccbedfffafa93a9f1da2e8c19c1711052799acf3b58ae5bebb5c6bd7b;
     address deployer = vm.addr(privateKeyDeployer);
 
@@ -101,11 +102,9 @@ contract HolographTests is Test {
     * performs a prank operation on the admin address using the VM,
     * and then sets a new admin address to the contract.
     */
-    // TODO Admin does not correspond to the address that performs the init
     function testSetAdmin() public {
-        admin = holograph.getAdmin();
-        vm.prank(admin);
-        holograph.setAdmin(user);
+        vm.prank(origin);
+        holograph.setAdmin(admin);
     }
 
     /**
@@ -156,7 +155,7 @@ contract HolographTests is Test {
     * and then sets a new random address as the bridge in the contract.
     */
     function testAllowAdminAlter_bridgeSlot() public {
-        vm.prank(holograph.admin());
+        vm.prank(origin);
         holograph.setBridge(randomAddress());
     }
 
@@ -221,7 +220,7 @@ contract HolographTests is Test {
     * and then sets a new random address as the chainId in the contract.
     */
     function testAllowAdminAlter_chainIdSlot() public {
-        vm.prank(holograph.admin());
+        vm.prank(origin);
         holograph.setChainId((2));
     }
 
@@ -285,7 +284,7 @@ contract HolographTests is Test {
     * and then sets a new random address as the factory in the contract.
     */
     function testAllowAdminAlter_factorySlot() public {
-        vm.prank(holograph.admin());
+        vm.prank(origin);
         holograph.setFactory(randomAddress());
     }
 
@@ -349,7 +348,7 @@ contract HolographTests is Test {
     * and then sets a new random address as the holographChainId in the contract.
     */
     function testAllowAdminAlter_holographChainIdSlot() public {
-        vm.prank(holograph.admin());
+        vm.prank(origin);
         holograph.setHolographChainId(2);
     }
 
@@ -413,7 +412,7 @@ contract HolographTests is Test {
     * and then sets a new random address as the interfaces in the contract.
     */
     function testAllowAdminAlter_interfacesSlot() public {
-        vm.prank(holograph.admin());
+        vm.prank(origin);
         holograph.setInterfaces(randomAddress());
     }
 
@@ -477,7 +476,7 @@ contract HolographTests is Test {
     * and then sets a new random address as the operator in the contract.
     */
     function testAllowAdminAlter_operatorSlot() public {
-        vm.prank(holograph.admin());
+        vm.prank(origin);
         holograph.setOperator(randomAddress());
     }
 
@@ -541,7 +540,7 @@ contract HolographTests is Test {
     * and then sets a new random address as the registry in the contract.
     */
     function testAllowAdminAlter_registrySlot() public {
-        vm.prank(holograph.admin());
+        vm.prank(origin);
         holograph.setRegistry(randomAddress());
     }
 
@@ -605,7 +604,7 @@ contract HolographTests is Test {
     * and then sets a new random address as the treasury in the contract.
     */
     function testAllowAdminAlter_treasurySlot() public {
-        vm.prank(holograph.admin());
+        vm.prank(origin);
         holograph.setTreasury(randomAddress());
     }
 
@@ -669,7 +668,7 @@ contract HolographTests is Test {
     * and then sets a new random address as the utilityToken in the contract.
     */
     function testAllowAdminAlter_utilityTokenSlot() public {
-        vm.prank(holograph.admin());
+        vm.prank(origin);
         holograph.setUtilityToken(randomAddress());
     }
 


### PR DESCRIPTION
Add `/tests/foudnry/deploy/10_holograph_tests.t.sol`, which is the Foundry transcription for `/test/10_holograph_tests.t.sol`.
Comments in NatSpec format are included.
