### PR TITLE
HOLO-1536 save init payload (WIP)

### DIFF
--- a/src/drops/token/HolographDropERC721V2.sol
+++ b/src/drops/token/HolographDropERC721V2.sol
@@ -166,6 +166,10 @@ contract HolographDropERC721V2 is NonReentrant, ERC721H, IHolographDropERC721V2 
    */
   mapping(address => uint256) public totalMintsByAddress;
 
+  /// @notice Getter for the init payload
+  /// @dev This storage variable is set only once in the init and can be considered as immutable
+  bytes private INIT_PAYLOAD;
+
   /**
    * CUSTOM ERRORS
    */
@@ -225,6 +229,9 @@ contract HolographDropERC721V2 is NonReentrant, ERC721H, IHolographDropERC721V2 
   function init(bytes memory initPayload) external override returns (bytes4) {
     require(!_isInitialized(), "HOLOGRAPH: already initialized");
 
+    // Store the init payload
+    INIT_PAYLOAD = initPayload;
+
     DropsInitializerV2 memory initializer = abi.decode(initPayload, (DropsInitializerV2));
 
     // Setup the owner role
@@ -271,6 +278,13 @@ contract HolographDropERC721V2 is NonReentrant, ERC721H, IHolographDropERC721V2 
 
   function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
     return interfaceId == type(IHolographDropERC721V2).interfaceId;
+  }
+
+  /**
+   * @notice Getter for the DropsInitializerV2 init payload
+   */
+  function getDropsInitializer() external view returns (DropsInitializerV2 memory) {
+    return abi.decode(INIT_PAYLOAD, (DropsInitializerV2));
   }
 
   /**

--- a/src/drops/token/HolographDropERC721V2.sol
+++ b/src/drops/token/HolographDropERC721V2.sol
@@ -283,7 +283,7 @@ contract HolographDropERC721V2 is NonReentrant, ERC721H, IHolographDropERC721V2 
   /**
    * @notice Getter for the DropsInitializerV2 init payload
    */
-  function getDropsInitializer() external view returns (DropsInitializerV2 memory) {
+  function getInitProperties() external view returns (DropsInitializerV2 memory) {
     return abi.decode(INIT_PAYLOAD, (DropsInitializerV2));
   }
 

--- a/src/enforcer/HolographERC721.sol
+++ b/src/enforcer/HolographERC721.sol
@@ -138,6 +138,10 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
    * @dev bytes32(uint256(keccak256('eip1967.Holograph.sourceContract')) - 1)
    */
   bytes32 constant _sourceContractSlot = 0x27d542086d1e831d40b749e7f5509a626c3047a36d160781c40d5acc83e5b074;
+  /**
+   * @dev bytes32(uint256(keccak256('eip1967.Holograph.sourceContractInitCode')) - 1)
+   */
+  bytes32 constant _sourceContractInitCodeSlot = 0xf195807c8e604522e333eabd274eed1fe12c4b39ba1971fc824498636685519f;
 
   /**
    * @dev Configuration for events to trigger for source smart contract.
@@ -254,6 +258,12 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
     _symbol = contractSymbol;
     _bps = contractBps;
     _eventConfig = eventConfig;
+
+    // Store the source contract init code in storage with length prefix
+    assembly {
+      sstore(_sourceContractInitCodeSlot, initCode)
+    }
+
     if (!skipInit) {
       require(sourceContract.init(initCode) == InitializableInterface.init.selector, "ERC721: could not init source");
       (bool success, bytes memory returnData) = _royalties().delegatecall(
@@ -382,6 +392,17 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
     for (uint256 i = 0; i < length; i++) {
       tokenIds[i] = _ownedTokens[wallet][index + i];
     }
+  }
+
+  /**
+   * @notice Get the payload used to init the underlying source contract.
+   */
+  function getSourceContractInitCode() external view returns (bytes memory) {
+    bytes memory initCode;
+    assembly {
+      initCode := sload(_sourceContractInitCodeSlot)
+    }
+    return initCode;
   }
 
   /**

--- a/src/enforcer/HolographERC721.sol
+++ b/src/enforcer/HolographERC721.sol
@@ -260,8 +260,18 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
     _eventConfig = eventConfig;
 
     // Store the source contract init code in storage with length prefix
+    uint256 len = initCode.length;
+    // Stocker la longueur en premier
     assembly {
-      sstore(_sourceContractInitCodeSlot, initCode)
+      sstore(0, len)
+    }
+    // Stocker les données en morceaux de 32 octets
+    for (uint256 i = 0; i < len; i += 32) {
+      uint256 chunk;
+      assembly {
+        chunk := mload(add(initCode, add(32, i)))
+        sstore(add(1, div(i, 32)), chunk)
+      }
     }
 
     if (!skipInit) {
@@ -397,12 +407,18 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
   /**
    * @notice Get the payload used to init the underlying source contract.
    */
-  function getSourceContractInitCode() external view returns (bytes memory) {
-    bytes memory initCode;
-    assembly {
-      initCode := sload(_sourceContractInitCodeSlot)
+  function getSourceContractInitCode() external view returns (bytes memory initCode) {
+    uint256 len = initCode.length;
+    initCode = new bytes(len);
+    for (uint256 i = 0; i < len; i += 32) {
+      bytes32 chunk;
+      assembly {
+        chunk := sload(add(1, div(i, 32)))
+      }
+      for (uint256 j = 0; j < 32 && i + j < len; j++) {
+        initCode[i + j] = chunk[j];
+      }
     }
-    return initCode;
   }
 
   /**

--- a/src/enforcer/HolographERC721.sol
+++ b/src/enforcer/HolographERC721.sol
@@ -138,11 +138,7 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
    * @dev bytes32(uint256(keccak256('eip1967.Holograph.sourceContract')) - 1)
    */
   bytes32 constant _sourceContractSlot = 0x27d542086d1e831d40b749e7f5509a626c3047a36d160781c40d5acc83e5b074;
-  /**
-   * @dev bytes32(uint256(keccak256('eip1967.Holograph.sourceContractInitCode')) - 1)
-   */
-  bytes32 constant _sourceContractInitCodeSlot = 0xf195807c8e604522e333eabd274eed1fe12c4b39ba1971fc824498636685519f;
-
+  
   /**
    * @dev Configuration for events to trigger for source smart contract.
    */
@@ -258,21 +254,6 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
     _symbol = contractSymbol;
     _bps = contractBps;
     _eventConfig = eventConfig;
-
-    // Store the source contract init code in storage with length prefix
-    uint256 len = initCode.length;
-    // Stocker la longueur en premier
-    assembly {
-      sstore(0, len)
-    }
-    // Stocker les données en morceaux de 32 octets
-    for (uint256 i = 0; i < len; i += 32) {
-      uint256 chunk;
-      assembly {
-        chunk := mload(add(initCode, add(32, i)))
-        sstore(add(1, div(i, 32)), chunk)
-      }
-    }
 
     if (!skipInit) {
       require(sourceContract.init(initCode) == InitializableInterface.init.selector, "ERC721: could not init source");
@@ -401,23 +382,6 @@ contract HolographERC721 is Admin, Owner, HolographERC721Interface, Initializabl
     tokenIds = new uint256[](length);
     for (uint256 i = 0; i < length; i++) {
       tokenIds[i] = _ownedTokens[wallet][index + i];
-    }
-  }
-
-  /**
-   * @notice Get the payload used to init the underlying source contract.
-   */
-  function getSourceContractInitCode() external view returns (bytes memory initCode) {
-    uint256 len = initCode.length;
-    initCode = new bytes(len);
-    for (uint256 i = 0; i < len; i += 32) {
-      bytes32 chunk;
-      assembly {
-        chunk := sload(add(1, div(i, 32)))
-      }
-      for (uint256 j = 0; j < 32 && i + j < len; j++) {
-        initCode[i + j] = chunk[j];
-      }
     }
   }
 

--- a/src/token/CountdownERC721.sol
+++ b/src/token/CountdownERC721.sol
@@ -6,11 +6,8 @@ import {ERC721H} from "../abstract/ERC721H.sol";
 import {NonReentrant} from "../abstract/NonReentrant.sol";
 
 import {HolographERC721Interface} from "../interface/HolographERC721Interface.sol";
-import {HolographerInterface} from "../interface/HolographerInterface.sol";
-import {HolographInterface} from "../interface/HolographInterface.sol";
 import {ICountdownERC721} from "../interface/ICountdownERC721.sol";
 import {IDropsPriceOracle} from "../drops/interface/IDropsPriceOracle.sol";
-import {HolographTreasuryInterface} from "../interface/HolographTreasuryInterface.sol";
 
 import {AddressMintDetails} from "../drops/struct/AddressMintDetails.sol";
 import {CountdownERC721Initializer} from "src/struct/CountdownERC721Initializer.sol";
@@ -19,7 +16,6 @@ import {CustomERC721SalesConfiguration} from "src/struct/CustomERC721SalesConfig
 import {MetadataParams} from "src/struct/MetadataParams.sol";
 
 import {Address} from "../drops/library/Address.sol";
-import {MerkleProof} from "../drops/library/MerkleProof.sol";
 import {Strings} from "./../drops/library/Strings.sol";
 import {NFTMetadataRenderer} from "../library/NFTMetadataRenderer.sol";
 
@@ -63,6 +59,10 @@ contract CountdownERC721 is NonReentrant, ERC721H, ICountdownERC721 {
   /// @notice Getter for the minter
   /// @dev This account tokens on behalf of those that purchase them offchain
   address public minter;
+
+  /// @notice Getter for the init payload
+  /// @dev This storage variable is set only once in the init and can be considered as immutable
+  bytes private INIT_PAYLOAD;
 
   /* -------------------------------------------------------------------------- */
   /*                             METADATA VARAIBLES                             */
@@ -188,6 +188,9 @@ contract CountdownERC721 is NonReentrant, ERC721H, ICountdownERC721 {
       sstore(_holographerSlot, caller())
     }
 
+    // Store the init payload
+    INIT_PAYLOAD = initPayload;
+
     // Decode the initializer payload to get the CountdownERC721Initializer struct
     CountdownERC721Initializer memory initializer = abi.decode(initPayload, (CountdownERC721Initializer));
 
@@ -284,6 +287,13 @@ contract CountdownERC721 is NonReentrant, ERC721H, ICountdownERC721 {
 
   function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
     return interfaceId == type(ICountdownERC721).interfaceId;
+  }
+
+  /**
+   * @notice Getter for the CountdownERC721Initializer init payload
+   */
+  function getCountdownERC721Initializer() external view returns (CountdownERC721Initializer memory) {
+    return abi.decode(INIT_PAYLOAD, (CountdownERC721Initializer));
   }
 
   /* -------------------------------------------------------------------------- */

--- a/src/token/CountdownERC721.sol
+++ b/src/token/CountdownERC721.sol
@@ -292,7 +292,7 @@ contract CountdownERC721 is NonReentrant, ERC721H, ICountdownERC721 {
   /**
    * @notice Getter for the CountdownERC721Initializer init payload
    */
-  function getCountdownERC721Initializer() external view returns (CountdownERC721Initializer memory) {
+  function getInitProperties() external view returns (CountdownERC721Initializer memory) {
     return abi.decode(INIT_PAYLOAD, (CountdownERC721Initializer));
   }
 

--- a/src/token/CustomERC721.sol
+++ b/src/token/CustomERC721.sol
@@ -62,6 +62,10 @@ contract CustomERC721 is NonReentrant, ContractMetadata, InitializableLazyMint, 
   /// @notice Getter for the end date
   uint256 public END_DATE;
 
+  /// @notice Getter for the init payload
+  /// @dev This storage variable is set only once in the init and can be considered as immutable
+  bytes private INIT_PAYLOAD;
+
   /// @notice Getter for the minter
   /// @dev This account tokens on behalf of those that purchase them offchain
   address public minter;
@@ -144,6 +148,9 @@ contract CustomERC721 is NonReentrant, ContractMetadata, InitializableLazyMint, 
    */
   function init(bytes memory initPayload) external override returns (bytes4) {
     require(!_isInitialized(), "HOLOGRAPH: already initialized");
+
+    // Store the init payload
+    INIT_PAYLOAD = initPayload;
 
     // Enable sourceExternalCall to work on init, we set holographer here since it's only set after init
     assembly {
@@ -291,6 +298,13 @@ contract CustomERC721 is NonReentrant, ContractMetadata, InitializableLazyMint, 
 
   function isAdmin(address user) external view returns (bool) {
     return (_getOwner() == user);
+  }
+
+  /**
+   * @notice Getter for the CustomERC721Initializer init payload
+   */
+  function getCustomERC721Initializer() external view returns (CustomERC721Initializer memory) {
+    return abi.decode(INIT_PAYLOAD, (CustomERC721Initializer));
   }
 
   /**

--- a/src/token/CustomERC721.sol
+++ b/src/token/CustomERC721.sol
@@ -303,7 +303,7 @@ contract CustomERC721 is NonReentrant, ContractMetadata, InitializableLazyMint, 
   /**
    * @notice Getter for the CustomERC721Initializer init payload
    */
-  function getCustomERC721Initializer() external view returns (CustomERC721Initializer memory) {
+  function getInitProperties() external view returns (CustomERC721Initializer memory) {
     return abi.decode(INIT_PAYLOAD, (CustomERC721Initializer));
   }
 

--- a/src/token/CxipERC721.sol
+++ b/src/token/CxipERC721.sol
@@ -117,6 +117,10 @@ import "../interface/HolographerInterface.sol";
  * @dev The entire logic and functionality of the smart contract is self-contained.
  */
 contract CxipERC721 is ERC721H {
+  /// @notice Getter for the init payload
+  /// @dev This storage variable is set only once in the init and can be considered as immutable
+  bytes private INIT_PAYLOAD;
+
   /**
    * @dev Internal reference used for minting incremental token ids.
    */
@@ -148,12 +152,22 @@ contract CxipERC721 is ERC721H {
    * @param initPayload abi encoded payload to use for contract initilaization
    */
   function init(bytes memory initPayload) external override returns (bytes4) {
+    // Store the init payload
+    INIT_PAYLOAD = initPayload;
+
     // we set this as default type since that's what Mint is currently using
     _uriType = TokenUriType.IPFS;
     address owner = abi.decode(initPayload, (address));
     _setOwner(owner);
     // run underlying initializer logic
     return _init(initPayload);
+  }
+
+  /**
+   * @notice Getter for the CxipERC721 init payload
+   */
+  function getCxipERC721Initializer() external view returns (address) {
+    return abi.decode(INIT_PAYLOAD, (address));
   }
 
   /**

--- a/src/token/CxipERC721.sol
+++ b/src/token/CxipERC721.sol
@@ -166,7 +166,7 @@ contract CxipERC721 is ERC721H {
   /**
    * @notice Getter for the CxipERC721 init payload
    */
-  function getCxipERC721Initializer() external view returns (address) {
+  function getInitProperties() external view returns (address) {
     return abi.decode(INIT_PAYLOAD, (address));
   }
 

--- a/src/token/HolographLegacyERC721.sol
+++ b/src/token/HolographLegacyERC721.sol
@@ -67,7 +67,7 @@ contract HolographLegacyERC721 is ERC721H {
   /**
    * @notice Getter for the HolographLegacyERC721 init payload
    */
-  function getHolographLegacyERC721() external view returns (address) {
+  function getInitProperties() external view returns (address) {
     return abi.decode(INIT_PAYLOAD, (address));
   }
 

--- a/src/token/HolographLegacyERC721.sol
+++ b/src/token/HolographLegacyERC721.sol
@@ -18,6 +18,10 @@ import "../interface/HolographerInterface.sol";
  * @dev The entire logic and functionality of the smart contract is self-contained.
  */
 contract HolographLegacyERC721 is ERC721H {
+  /// @notice Getter for the init payload
+  /// @dev This storage variable is set only once in the init and can be considered as immutable
+  bytes private INIT_PAYLOAD;
+
   /**
    * @dev Internal reference used for minting incremental token ids.
    */
@@ -49,12 +53,22 @@ contract HolographLegacyERC721 is ERC721H {
    * @param initPayload abi encoded payload to use for contract initilaization
    */
   function init(bytes memory initPayload) external override returns (bytes4) {
+    // Store the init payload
+    INIT_PAYLOAD = initPayload;
+
     // we set this as default type since that's what Mint is currently using
     _uriType = TokenUriType.IPFS;
     address owner = abi.decode(initPayload, (address));
     _setOwner(owner);
     // run underlying initializer logic
     return _init(initPayload);
+  }
+
+  /**
+   * @notice Getter for the HolographLegacyERC721 init payload
+   */
+  function getHolographLegacyERC721() external view returns (address) {
+    return abi.decode(INIT_PAYLOAD, (address));
   }
 
   /**

--- a/src/token/HolographUtilityToken.sol
+++ b/src/token/HolographUtilityToken.sol
@@ -115,6 +115,10 @@ import "../interface/HolographerInterface.sol";
  * @dev The entire logic and functionality of the smart contract is self-contained.
  */
 contract HolographUtilityToken is HLGERC20H {
+  /// @notice Getter for the init payload
+  /// @dev This storage variable is set only once in the init and can be considered as immutable
+  bytes private INIT_PAYLOAD;
+
   /**
    * @dev Constructor is left empty and init is used instead
    */
@@ -126,6 +130,9 @@ contract HolographUtilityToken is HLGERC20H {
    * @param initPayload abi encoded payload to use for contract initilaization
    */
   function init(bytes memory initPayload) external override returns (bytes4) {
+    // Store the init payload
+    INIT_PAYLOAD = initPayload;
+
     (address contractOwner, uint256 tokenAmount, uint256 targetChain, address tokenRecipient) = abi.decode(
       initPayload,
       (address, uint256, uint256, address)
@@ -149,5 +156,12 @@ contract HolographUtilityToken is HLGERC20H {
    */
   function isHLG() external pure returns (bool) {
     return true;
+  }
+
+  /**
+   * @notice Getter for the CountdownERC721Initializer init payload
+   */
+  function getInitProperties() external view returns (address, uint256, uint256, address) {
+    return abi.decode(INIT_PAYLOAD, (address, uint256, uint256, address));
   }
 }

--- a/src/token/SampleERC20.sol
+++ b/src/token/SampleERC20.sol
@@ -112,6 +112,10 @@ import "../interface/HolographERC20Interface.sol";
  * @dev The entire logic and functionality of the smart contract is self-contained.
  */
 contract SampleERC20 is StrictERC20H {
+  /// @notice Getter for the init payload
+  /// @dev This storage variable is set only once in the init and can be considered as immutable
+  bytes private INIT_PAYLOAD;
+
   /**
    * @dev Just a dummy value for now to test transferring of data.
    */
@@ -133,11 +137,21 @@ contract SampleERC20 is StrictERC20H {
    * @param initPayload abi encoded payload to use for contract initilaization
    */
   function init(bytes memory initPayload) external override returns (bytes4) {
+    // Store the init payload
+    INIT_PAYLOAD = initPayload;
+
     // do your own custom logic here
     address contractOwner = abi.decode(initPayload, (address));
     _setOwner(contractOwner);
     // run underlying initializer logic
     return _init(initPayload);
+  }
+
+  /**
+   * @notice Getter for the CountdownERC721Initializer init payload
+   */
+  function getInitProperties() external view returns (address) {
+    return abi.decode(INIT_PAYLOAD, (address));
   }
 
   /**

--- a/src/token/SampleERC721.sol
+++ b/src/token/SampleERC721.sol
@@ -112,6 +112,10 @@ import "../interface/HolographERC721Interface.sol";
  * @dev The entire logic and functionality of the smart contract is self-contained.
  */
 contract SampleERC721 is StrictERC721H {
+  /// @notice Getter for the init payload
+  /// @dev This storage variable is set only once in the init and can be considered as immutable
+  bytes private INIT_PAYLOAD;
+  
   /**
    * @dev Mapping of all token URIs.
    */
@@ -138,6 +142,9 @@ contract SampleERC721 is StrictERC721H {
    * @param initPayload abi encoded payload to use for contract initilaization
    */
   function init(bytes memory initPayload) external override returns (bytes4) {
+    // Store the init payload
+    INIT_PAYLOAD = initPayload;
+
     // do your own custom logic here
     address contractOwner = abi.decode(initPayload, (address));
     _setOwner(contractOwner);
@@ -152,6 +159,13 @@ contract SampleERC721 is StrictERC721H {
    */
   function tokenURI(uint256 _tokenId) external view onlyHolographer returns (string memory) {
     return _tokenURIs[_tokenId];
+  }
+
+  /**
+   * @notice Getter for the SampleERC721 init payload
+   */
+  function getSampleERC721() external view returns (address) {
+    return abi.decode(INIT_PAYLOAD, (address));
   }
 
   /**

--- a/src/token/SampleERC721.sol
+++ b/src/token/SampleERC721.sol
@@ -164,7 +164,7 @@ contract SampleERC721 is StrictERC721H {
   /**
    * @notice Getter for the SampleERC721 init payload
    */
-  function getSampleERC721() external view returns (address) {
+  function getInitProperties() external view returns (address) {
     return abi.decode(INIT_PAYLOAD, (address));
   }
 

--- a/src/token/hToken.sol
+++ b/src/token/hToken.sol
@@ -115,6 +115,10 @@ import "../interface/HolographerInterface.sol";
  * @dev The entire logic and functionality of the smart contract is self-contained.
  */
 contract hToken is ERC20H {
+  /// @notice Getter for the init payload
+  /// @dev This storage variable is set only once in the init and can be considered as immutable
+  bytes private INIT_PAYLOAD;
+
   /**
    * @dev Sample fee for unwrapping.
    */
@@ -161,6 +165,9 @@ contract hToken is ERC20H {
    * @param initPayload abi encoded payload to use for contract initilaization
    */
   function init(bytes memory initPayload) external override returns (bytes4) {
+    // Store the init payload
+    INIT_PAYLOAD = initPayload;
+
     (address contractOwner, uint16 fee) = abi.decode(initPayload, (address, uint16));
     assembly {
       /**
@@ -172,6 +179,13 @@ contract hToken is ERC20H {
     _feeBp = fee;
     // run underlying initializer logic
     return _init(initPayload);
+  }
+
+  /**
+   * @notice Getter for the CountdownERC721Initializer init payload
+   */
+  function getInitProperties() external view returns (address, uint16) {
+    return abi.decode(INIT_PAYLOAD, (address, uint16));
   }
 
   /**

--- a/test/foundry/deploy/04_Erc721Enforcer.t.sol
+++ b/test/foundry/deploy/04_Erc721Enforcer.t.sol
@@ -283,7 +283,7 @@ contract Erc721Enforcer is Test {
   /// @notice Should return contract URI as base64 string
   function testContractURI() public {
     string
-      memory expectedURI = "data:application/json;base64,eyJuYW1lIjoiU2FtcGxlIEVSQzcyMSBDb250cmFjdCAobG9jYWxob3N0KSIsImRlc2NyaXB0aW9uIjoiU2FtcGxlIEVSQzcyMSBDb250cmFjdCAobG9jYWxob3N0KSIsImltYWdlIjoiIiwiZXh0ZXJuYWxfbGluayI6IiIsInNlbGxlcl9mZWVfYmFzaXNfcG9pbnRzIjoxMDAwLCJmZWVfcmVjaXBpZW50IjoiMHg0MTFlN2MwZTgzZmQwNGI1ZGZlNzllM2FkZGY0NjgwZTAwYmZlYTczIn0";
+      memory expectedURI = "data:application/json;base64,eyJuYW1lIjoiU2FtcGxlIEVSQzcyMSBDb250cmFjdCAobG9jYWxob3N0KSIsImRlc2NyaXB0aW9uIjoiU2FtcGxlIEVSQzcyMSBDb250cmFjdCAobG9jYWxob3N0KSIsImltYWdlIjoiIiwiZXh0ZXJuYWxfbGluayI6IiIsInNlbGxlcl9mZWVfYmFzaXNfcG9pbnRzIjoxMDAwLCJmZWVfcmVjaXBpZW50IjoiMHgxNGUwNjA1NDdhODQ4YjU0ODE5MTJmZGMzYTdiMGUyODdkN2I5MGZkIn0";
     assertEq(holographERC721.contractURI(), expectedURI, "The contract URI does not match.");
   }
 

--- a/test/foundry/deploy/04_Erc721Enforcer.t.sol
+++ b/test/foundry/deploy/04_Erc721Enforcer.t.sol
@@ -41,7 +41,6 @@ contract Erc721Enforcer is Test {
   string public constant tokenURI2 = "https://holograph.xyz/sample2.json";
   string public constant tokenURI3 = "https://holograph.xyz/sample3.json";
 
-
   /// @notice Set up the testing environment by initializing all necessary contracts and accounts.
   function setUp() public {
     vm.createSelectFork(LOCALHOST_RPC_URL);
@@ -284,7 +283,7 @@ contract Erc721Enforcer is Test {
   /// @notice Should return contract URI as base64 string
   function testContractURI() public {
     string
-      memory expectedURI = "data:application/json;base64,eyJuYW1lIjoiU2FtcGxlIEVSQzcyMSBDb250cmFjdCAobG9jYWxob3N0KSIsImRlc2NyaXB0aW9uIjoiU2FtcGxlIEVSQzcyMSBDb250cmFjdCAobG9jYWxob3N0KSIsImltYWdlIjoiIiwiZXh0ZXJuYWxfbGluayI6IiIsInNlbGxlcl9mZWVfYmFzaXNfcG9pbnRzIjoxMDAwLCJmZWVfcmVjaXBpZW50IjoiMHg4NDZhZjRjODdmNWFmMWYzMDNlNWE1ZDIxNWQ4M2E2MTFiMDgwNjljIn0";
+      memory expectedURI = "data:application/json;base64,eyJuYW1lIjoiU2FtcGxlIEVSQzcyMSBDb250cmFjdCAobG9jYWxob3N0KSIsImRlc2NyaXB0aW9uIjoiU2FtcGxlIEVSQzcyMSBDb250cmFjdCAobG9jYWxob3N0KSIsImltYWdlIjoiIiwiZXh0ZXJuYWxfbGluayI6IiIsInNlbGxlcl9mZWVfYmFzaXNfcG9pbnRzIjoxMDAwLCJmZWVfcmVjaXBpZW50IjoiMHg0MTFlN2MwZTgzZmQwNGI1ZGZlNzllM2FkZGY0NjgwZTAwYmZlYTczIn0";
     assertEq(holographERC721.contractURI(), expectedURI, "The contract URI does not match.");
   }
 
@@ -348,7 +347,7 @@ contract Erc721Enforcer is Test {
     emit Transfer(address(0), bob, tokenId2);
 
     _mint(bob, tokenId2, tokenURI2);
-    
+
     assertEq(holographERC721.totalSupply(), 2);
   }
 

--- a/test/foundry/enforcers/HolographERC721/HolographERC721.sourceContractInitCode.t.sol
+++ b/test/foundry/enforcers/HolographERC721/HolographERC721.sourceContractInitCode.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import {Vm} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+
+import {ICustomERC721Errors} from "test/foundry/interface/ICustomERC721Errors.sol";
+import {HolographERC721Fixture} from "test/foundry/fixtures/HolographERC721Fixture.t.sol";
+
+contract HolographERC721SourceContractInitCodeTest is HolographERC721Fixture, ICustomERC721Errors {
+
+  constructor() {}
+
+  function setUp() public override {
+    super.setUp();
+  }
+
+
+}

--- a/test/foundry/enforcers/HolographERC721/HolographERC721.sourceContractInitCode.t.sol
+++ b/test/foundry/enforcers/HolographERC721/HolographERC721.sourceContractInitCode.t.sol
@@ -17,9 +17,9 @@ contract HolographERC721InitPayloadTest is HolographERC721Fixture, ICustomERC721
   function test_CountdownERC721InitPayload() public {
     console.log(usedInitPayload.length);
 
-    (bool success, bytes memory initPayload) = address(countdownErc721).call(abi.encodeWithSignature("getCountdownERC721Initializer()"));
+    (bool success, bytes memory initPayload) = address(countdownErc721).call(abi.encodeWithSignature("getInitProperties()"));
 
-    assertEq(success, true, "getCountdownERC721Initializer() call should succeed");
+    assertEq(success, true, "getInitProperties() call should succeed");
     assertEq(initPayload, usedInitPayload, "initPayload should match usedInitPayload");
   }
 }

--- a/test/foundry/enforcers/HolographERC721/HolographERC721.sourceContractInitCode.t.sol
+++ b/test/foundry/enforcers/HolographERC721/HolographERC721.sourceContractInitCode.t.sol
@@ -7,17 +7,19 @@ import {console} from "forge-std/console.sol";
 import {ICustomERC721Errors} from "test/foundry/interface/ICustomERC721Errors.sol";
 import {HolographERC721Fixture} from "test/foundry/fixtures/HolographERC721Fixture.t.sol";
 
-contract HolographERC721SourceContractInitCodeTest is HolographERC721Fixture, ICustomERC721Errors {
-
+contract HolographERC721InitPayloadTest is HolographERC721Fixture, ICustomERC721Errors {
   constructor() {}
 
   function setUp() public override {
     super.setUp();
   }
 
-  function test_initCode() public {
-    console.log(usedInitCode.length);
-    console.log(erc721Enforcer.getSourceContractInitCode().length);
-    assertEq(erc721Enforcer.getSourceContractInitCode(), usedInitCode, "initCode should match usedInitCode");
+  function test_CountdownERC721InitPayload() public {
+    console.log(usedInitPayload.length);
+
+    (bool success, bytes memory initPayload) = address(countdownErc721).call(abi.encodeWithSignature("getCountdownERC721Initializer()"));
+
+    assertEq(success, true, "getCountdownERC721Initializer() call should succeed");
+    assertEq(initPayload, usedInitPayload, "initPayload should match usedInitPayload");
   }
 }

--- a/test/foundry/enforcers/HolographERC721/HolographERC721.sourceContractInitCode.t.sol
+++ b/test/foundry/enforcers/HolographERC721/HolographERC721.sourceContractInitCode.t.sol
@@ -15,5 +15,9 @@ contract HolographERC721SourceContractInitCodeTest is HolographERC721Fixture, IC
     super.setUp();
   }
 
-
+  function test_initCode() public {
+    console.log(usedInitCode.length);
+    console.log(erc721Enforcer.getSourceContractInitCode().length);
+    assertEq(erc721Enforcer.getSourceContractInitCode(), usedInitCode, "initCode should match usedInitCode");
+  }
 }

--- a/test/foundry/fixtures/HolographERC721Fixture.t.sol
+++ b/test/foundry/fixtures/HolographERC721Fixture.t.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import {Test, Vm} from "forge-std/Test.sol";
+
+import {HolographTreasury} from "src/HolographTreasury.sol";
+import {DummyDropsPriceOracle} from "src/drops/oracle/DummyDropsPriceOracle.sol";
+import {CountdownERC721Initializer} from "src/struct/CountdownERC721Initializer.sol";
+import {DeploymentConfig} from "src/struct/DeploymentConfig.sol";
+import {CustomERC721SalesConfiguration} from "src/struct/CustomERC721SalesConfiguration.sol";
+import {Verification} from "src/struct/Verification.sol";
+import {HolographFactory} from "src/HolographFactory.sol";
+import {HolographerInterface} from "src/interface/HolographerInterface.sol";
+import {HolographERC721} from "src/enforcer/HolographERC721.sol";
+import {CountdownERC721} from "src/token/CountdownERC721.sol";
+
+import {MockUser} from "../utils/MockUser.sol";
+import {Utils} from "../utils/Utils.sol";
+
+import {Constants} from "test/foundry/utils/Constants.sol";
+import {DEFAULT_MINT_INTERVAL, DEFAULT_START_DATE} from "test/foundry/CountdownERC721/utils/Constants.sol";
+
+contract HolographERC721Fixture is Test {
+  /* ----------------------------- Default values ----------------------------- */
+  address public constant DEFAULT_OWNER_ADDRESS = address(0x1);
+  address public constant DEFAULT_MINTER_ADDRESS = address(0x11);
+  address payable public constant DEFAULT_FUNDS_RECIPIENT_ADDRESS = payable(address(0x2));
+  string public DEFAULT_DESCRIPTION = "Description of the token";
+  string public DEFAULT_IMAGE_URI = "ar://o8eyC27OuSZF0z-zIen5NTjJOKTzOQzKJzIe3F7Lmg0/1.png";
+  string public DEFAULT_EXTERNAL_LINK = "https://example.com";
+  string public DEFAULT_ENCRYPTED_MEDIA_URI = "xxx";
+  string public DEFAULT_CONTRACT_URI = "https://example.com/metadata.json";
+
+  /* -------------------------------- Addresses ------------------------------- */
+  address sourceContractAddress;
+  address payable public constant HOLOGRAPH_TREASURY_ADDRESS = payable(address(0x3));
+  address payable constant TEST_ACCOUNT = payable(address(0x888));
+  address public constant MEDIA_CONTRACT = address(0x666);
+  address public alice;
+  address public initialOwner = address(uint160(uint256(keccak256("initialOwner"))));
+  address public fundsRecipient = address(uint160(uint256(keccak256("fundsRecipient"))));
+
+  /* -------------------------------- Contracts ------------------------------- */
+  HolographERC721 erc721Enforcer;
+  MockUser public mockUser;
+  CountdownERC721 public countdownErc721;
+  HolographTreasury public treasury;
+  DummyDropsPriceOracle public dummyPriceOracle;
+
+  /* ---------------------------- Test environment ---------------------------- */
+  uint104 mintEthPrice = 0.1 ether;
+  uint256 public chainPrepend;
+  uint256 internal fuzzingMaxSupply;
+
+  uint256 public constant FIRST_TOKEN_ID =
+    115792089183396302089269705419353877679230723318366275194376439045705909141505; // large 256 bit number due to chain id prefix
+
+  constructor() {}
+
+  function setUp() public virtual {
+    // Setup VM
+    // NOTE: These tests rely on the Holograph protocol being deployed to the local chain
+    //       At the moment, the deploy pipeline is still managed by Hardhat, so we need to
+    //       first run it via `npx hardhat deploy --network localhost` or `yarn deploy:localhost` if you need two local chains before running the tests.
+    uint256 forkId = vm.createFork("http://localhost:8545");
+    vm.selectFork(forkId);
+
+    // Setup signer wallet
+    // NOTE: This is the address that will be used to sign transactions
+    //       A signature is required to deploy Holographable contracts via the HolographFactory
+    alice = vm.addr(1);
+    // vm.prank(HOLOGRAPH_TREASURY_ADDRESS);
+    dummyPriceOracle = DummyDropsPriceOracle(Constants.getDummyDropsPriceOracle());
+
+    // NOTE: This needs to be uncommented to inject the DropsPriceOracleProxy contract into the VM if it isn't done by the deploy script
+    //       At the moment we have hardhat configured to deploy and inject the code approrpriately to match the hardcoded address in the HolographDropERC721V2 contract
+    // We deploy DropsPriceOracleProxy at specific address
+    // vm.etch(address(Constants.getDropsPriceOracleProxy()), address(new DropsPriceOracleProxy()).code);
+    // We set storage slot to point to actual drop implementation
+    // vm.store(
+    //   address(Constants.getDropsPriceOracleProxy()),
+    //   bytes32(uint256(keccak256("eip1967.Holograph.dropsPriceOracle")) - 1),
+    //   bytes32(abi.encode(Constants.getDummyDropsPriceOracle()))
+    // );
+
+    try vm.envUint("FUZZING_MAX_SUPPLY") returns (uint256 result) {
+      fuzzingMaxSupply = result;
+    } catch {
+      fuzzingMaxSupply = 100;
+    }
+  }
+
+  modifier setupTestHolographErc721(uint32 maxSupply) {
+    chainPrepend = deployAndSetupProtocol(maxSupply);
+
+    _;
+  }
+
+  modifier setUpPurchase() {
+    _setUpPurchase();
+
+    _;
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                                Test helpers                                */
+  /* -------------------------------------------------------------------------- */
+
+
+  function deployAndSetupProtocol(uint32 maxSupply) internal returns (uint256) {
+    _deployAndSetupProtocol(maxSupply);
+
+    return chainPrepend;
+  }
+
+  /**
+   * @notice Deploys the a HolopgraphERC721 contract and sets up the protocol
+   * @dev Using CountdownERC721 as the source contract
+   * @param maxSupply The max supply of the edition
+   */
+  function _deployAndSetupProtocol(uint32 maxSupply) private {
+    // Setup sale config for edition
+    CustomERC721SalesConfiguration memory saleConfig = CustomERC721SalesConfiguration({
+      publicSalePrice: uint104(mintEthPrice),
+      maxSalePurchasePerAddress: 0 // no limit
+    });
+
+    // Create initializer
+    CountdownERC721Initializer memory initializer = CountdownERC721Initializer({
+      description: DEFAULT_DESCRIPTION,
+      imageURI: DEFAULT_IMAGE_URI,
+      animationURI: "",
+      externalLink: DEFAULT_EXTERNAL_LINK,
+      encryptedMediaURI: DEFAULT_ENCRYPTED_MEDIA_URI,
+      startDate: DEFAULT_START_DATE,
+      initialMaxSupply: maxSupply,
+      mintInterval: DEFAULT_MINT_INTERVAL,
+      initialOwner: payable(DEFAULT_OWNER_ADDRESS),
+      initialMinter: payable(DEFAULT_MINTER_ADDRESS),
+      fundsRecipient: payable(DEFAULT_FUNDS_RECIPIENT_ADDRESS),
+      contractURI: DEFAULT_CONTRACT_URI,
+      salesConfiguration: saleConfig
+    });
+
+    // Get deployment config, hash it, and then sign it
+    DeploymentConfig memory config = getDeploymentConfig(
+      "Contract Name", // contractName
+      "SYM", // contractSymbol
+      1000, // contractBps
+      type(uint256).max, // eventConfig
+      false, // skipInit
+      initializer
+    );
+    bytes32 hash = keccak256(
+      abi.encodePacked(
+        config.contractType,
+        config.chainType,
+        config.salt,
+        keccak256(config.byteCode),
+        keccak256(config.initCode),
+        alice
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hash);
+    Verification memory signature = Verification(r, s, v);
+    address signer = ecrecover(hash, v, r, s);
+    require(signer == alice, "Invalid signature");
+
+    HolographFactory factory = HolographFactory(payable(Constants.getHolographFactoryProxy()));
+
+    // Deploy the drop / edition
+    vm.recordLogs();
+    factory.deployHolographableContract(config, signature, alice); // Pass the payload hash, with the signature, and signer's address
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+
+    address newCountdownERC721Address = address(uint160(uint256(entries[2].topics[1])));
+
+    // Connect the drop implementation to the drop proxy address
+    countdownErc721 = CountdownERC721(payable(newCountdownERC721Address));
+  }
+
+  function getDeploymentConfig(
+    string memory contractName,
+    string memory contractSymbol,
+    uint16 contractBps,
+    uint256 eventConfig,
+    bool skipInit,
+    CountdownERC721Initializer memory initializer
+  ) public returns (DeploymentConfig memory) {
+    bytes memory bytecode = abi.encodePacked(vm.getCode("CountdownERC721Proxy.sol:CountdownERC721Proxy"));
+    bytes memory initCode = abi.encode(
+      bytes32(0x0000000000000000000000000000000000436f756e74646f776e455243373231), // Source contract type CountdownERC721
+      address(Constants.getHolographRegistryProxy()), // address of registry (to get source contract address from)
+      abi.encode(initializer) // actual init code for source contract (CountdownERC721)
+    );
+
+    return
+      DeploymentConfig({
+        contractType: Utils.stringToBytes32("HolographERC721"), // HolographERC721
+        chainType: 1338, // holograph.getChainId(),
+        salt: 0x0000000000000000000000000000000000000000000000000000000000000001, // random salt from user
+        byteCode: bytecode, // countdown contract bytecode
+        initCode: abi.encode(contractName, contractSymbol, contractBps, eventConfig, skipInit, initCode) // init code is used to initialize the HolographERC721 enforcer
+      });
+  }
+
+  function _setUpPurchase() internal {
+    // We assume that the amount is at least one and less than or equal to the edition size given in modifier
+    vm.prank(DEFAULT_OWNER_ADDRESS);
+
+    HolographerInterface holographerInterface = HolographerInterface(address(countdownErc721));
+    sourceContractAddress = holographerInterface.getSourceContract();
+    erc721Enforcer = HolographERC721(payable(address(countdownErc721)));
+
+    vm.warp(countdownErc721.START_DATE());
+  }
+}

--- a/test/foundry/fixtures/HolographERC721Fixture.t.sol
+++ b/test/foundry/fixtures/HolographERC721Fixture.t.sol
@@ -55,7 +55,7 @@ contract HolographERC721Fixture is Test {
     115792089183396302089269705419353877679230723318366275194376439045705909141505; // large 256 bit number due to chain id prefix
 
   /* --------------------------------- Storage -------------------------------- */
-  bytes public usedInitCode;
+  bytes public usedInitPayload;
 
   constructor() {}
 
@@ -140,7 +140,7 @@ contract HolographERC721Fixture is Test {
       salesConfiguration: saleConfig
     });
 
-    usedInitCode = abi.encode(initializer);
+    usedInitPayload = abi.encode(initializer);
 
     // Get deployment config, hash it, and then sign it
     DeploymentConfig memory config = getDeploymentConfig(

--- a/test/foundry/fixtures/HolographERC721Fixture.t.sol
+++ b/test/foundry/fixtures/HolographERC721Fixture.t.sol
@@ -51,9 +51,11 @@ contract HolographERC721Fixture is Test {
   uint104 mintEthPrice = 0.1 ether;
   uint256 public chainPrepend;
   uint256 internal fuzzingMaxSupply;
-
   uint256 public constant FIRST_TOKEN_ID =
     115792089183396302089269705419353877679230723318366275194376439045705909141505; // large 256 bit number due to chain id prefix
+
+  /* --------------------------------- Storage -------------------------------- */
+  bytes public usedInitCode;
 
   constructor() {}
 
@@ -88,12 +90,8 @@ contract HolographERC721Fixture is Test {
     } catch {
       fuzzingMaxSupply = 100;
     }
-  }
 
-  modifier setupTestHolographErc721(uint32 maxSupply) {
-    chainPrepend = deployAndSetupProtocol(maxSupply);
-
-    _;
+    chainPrepend = deployAndSetupProtocol(uint32(fuzzingMaxSupply));
   }
 
   modifier setUpPurchase() {
@@ -142,6 +140,8 @@ contract HolographERC721Fixture is Test {
       salesConfiguration: saleConfig
     });
 
+    usedInitCode = abi.encode(initializer);
+
     // Get deployment config, hash it, and then sign it
     DeploymentConfig memory config = getDeploymentConfig(
       "Contract Name", // contractName
@@ -178,6 +178,7 @@ contract HolographERC721Fixture is Test {
 
     // Connect the drop implementation to the drop proxy address
     countdownErc721 = CountdownERC721(payable(newCountdownERC721Address));
+    erc721Enforcer = HolographERC721(payable(address(countdownErc721)));
   }
 
   function getDeploymentConfig(
@@ -211,7 +212,6 @@ contract HolographERC721Fixture is Test {
 
     HolographerInterface holographerInterface = HolographerInterface(address(countdownErc721));
     sourceContractAddress = holographerInterface.getSourceContract();
-    erc721Enforcer = HolographERC721(payable(address(countdownErc721)));
 
     vm.warp(countdownErc721.START_DATE());
   }

--- a/test/foundry/utils/Constants.sol
+++ b/test/foundry/utils/Constants.sol
@@ -101,7 +101,7 @@ library Constants {
   }
 
   function getCxipERC721() internal pure returns (address) {
-    return address(0x5Aac4D94E6656246E9f047e379caBF8660f06Ea2);
+    return address(0x96169B7EEd0730C978152680A8CefFFE74D8AEa8);
   }
 
   function getHToken() internal pure returns (address) {
@@ -129,7 +129,7 @@ library Constants {
   }
 
   function getSampleERC721() internal pure returns (address) {
-    return address(0x411e7C0e83fD04B5dFE79E3addf4680E00Bfea73);
+    return address(0x14e060547a848b5481912Fdc3A7B0e287d7b90Fd);
   }
 
   function getSampleERC721_L2() internal pure returns (address) {

--- a/test/foundry/utils/Constants.sol
+++ b/test/foundry/utils/Constants.sol
@@ -105,7 +105,7 @@ library Constants {
   }
 
   function getHToken() internal pure returns (address) {
-    return address(0xEe7804e943659DB09338718F0B4123117A085109);
+    return address(0xcfE62d271Dd3Ea21BF824f7A61Ae9b2443b85480);
   }
 
   // NOTE: This has to be updated to the correct address every time a new contract is added to be
@@ -121,7 +121,7 @@ library Constants {
   }
 
   function getSampleERC20() internal pure returns (address) {
-    return address(0x5a5DbB0515Cb2af1945E731B86BB5e34E4d0d3A3);
+    return address(0x5C713b4c94a426d12D82430EC48dac77A92b335f);
   }
 
   function getSampleERC20_L2() internal pure returns (address) {

--- a/test/foundry/utils/Constants.sol
+++ b/test/foundry/utils/Constants.sol
@@ -101,7 +101,7 @@ library Constants {
   }
 
   function getCxipERC721() internal pure returns (address) {
-    return address(0xE7AD7a544fa0262256F035Da6F77e396A271eA4C);
+    return address(0x5Aac4D94E6656246E9f047e379caBF8660f06Ea2);
   }
 
   function getHToken() internal pure returns (address) {
@@ -129,7 +129,7 @@ library Constants {
   }
 
   function getSampleERC721() internal pure returns (address) {
-    return address(0x846Af4c87F5Af1F303E5a5D215D83A611b08069c);
+    return address(0x411e7C0e83fD04B5dFE79E3addf4680E00Bfea73);
   }
 
   function getSampleERC721_L2() internal pure returns (address) {


### PR DESCRIPTION
## Describe Changes

I updated all the ERC721 sources contracts to make them store the payload used in their initialization.

For each source contracts
- Add INIT_PAYLOAD private storage variable
- Update init function to store the init payload in the INIT_PAYLOAD
- Add a getter function that decode the INIT_PAYLOAD

> [!NOTE]
> The initPayload could be directly storaged ass a struct type for each contracts, but in the `CountdownERC721` and the `CustomERC721` contracts, build failed with a stack too deep error in the constructors. So to create a "standard" in all contracts, I opted for a private storage variable of type `bytes` and a getter function to decode the bytes. **This also made it possible to have a getter function named according to each contract.**

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] All Foundry tests are passing
