### PR TITLE
HAL-04: Add warning to HolographOperator for setUtilityToken

### DIFF
--- a/src/HolographOperator.sol
+++ b/src/HolographOperator.sol
@@ -1006,6 +1006,11 @@ contract HolographOperator is Admin, Initializable, HolographOperatorInterface {
 
   /**
    * @notice Update the Holograph Utility Token address
+   * @dev WARNING!!!
+   *      This function should only be used in the event of a token migration which should never happen
+   *      Updating this will break all the slashing and bonding logic
+   *      To update the utility token in a safe way before calling this function,
+   *      the _bondedAmounts and _operatorPods arrays should reset to zero
    * @param utilityToken address of the Holograph Utility Token smart contract to use
    */
   function setUtilityToken(address utilityToken) external onlyAdmin {

--- a/test/foundry/utils/Constants.sol
+++ b/test/foundry/utils/Constants.sol
@@ -41,7 +41,7 @@ library Constants {
   }
 
   function getHolographOperator() internal pure returns (address) {
-    return address(0xb03ee8D15C046b25eD006e247f71d6F27920624f);
+    return address(0x53C56B06B2791F21aeE4B0816EBdBeF825739E58);
   }
 
   function getHolographOperatorProxy() internal pure returns (address) {


### PR DESCRIPTION
## Description

This simply provides a warning for an issue identified by Halborn. We would like to keep the function for now although it should never need to be called outside of a dev environment. In the super unlikely reason this would ever need to be called on production, the warning provides instructions for clearing the `_bondedAmounts` mapping during the migration.

The HolographOperator contract implements the function setUtilityToken():
```
/**
 * @notice Update the Holograph Utility Token address
 * @param utilityToken address of the Holograph Utility Token smart contract to use
 */
function setUtilityToken(address utilityToken) external onlyAdmin {
  assembly {
    sstore(_utilityTokenSlot, utilityToken)
  }
}

```
However, when a new utility token is set by an admin, the _bondedAmounts mapping is not reset to 0, breaking all the slashing infrastructure.

Recommendation
When a new utility token is set by an admin all the _bondedAmounts keys should be reset to 0. On the other hand, as the previous suggestion is nearly impossible to implement without very high gas costs, consinder simply removing the setUtilityToken() function.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code styles have been enforced
- [ ] All Foundry tests are passing
